### PR TITLE
fix: allows device passcode to access secure store

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,7 +58,7 @@ jobs:
           rm '/usr/local/bin/pydoc3.11'
           rm '/usr/local/bin/python3.11'
           rm '/usr/local/bin/python3.11-config'
-          
+
           bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
           
           brew install sonar-scanner

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,7 +58,7 @@ jobs:
           rm '/usr/local/bin/pydoc3.11'
           rm '/usr/local/bin/python3.11'
           rm '/usr/local/bin/python3.11-config'
-
+          
           bash xccov-to-sonarqube-generic.sh result.xcresult/ >Coverage.xml
           
           brew install sonar-scanner

--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -12,18 +12,19 @@ public struct SecureStorageConfiguration {
     public enum AccessControlLevel {
         case `open`
         case anyBiometricsOnly
-        case currentBiometricsOnly
-        case currentBiometricsOrPasscode
         @available(*, deprecated, renamed: "anyBiometricsOnly")
         case anyBiometricsOrPasscode
+        case currentBiometricsOnly
+        case currentBiometricsOrPasscode
+
 
         var flags: SecAccessControlCreateFlags {
             switch self {
             case .open:
                 return []
-            case .anyBiometricsOrPasscode:
-                return [.privateKeyUsage, .biometryAny]
             case .anyBiometricsOnly:
+                return [.privateKeyUsage, .biometryAny]
+            case .anyBiometricsOrPasscode:
                 return [.privateKeyUsage, .biometryAny]
             case .currentBiometricsOnly:
                 return [.privateKeyUsage, .biometryCurrentSet]

--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -21,7 +21,7 @@ public struct SecureStorageConfiguration {
             case .anyBiometricsOrPasscode:
                 return [.privateKeyUsage, .biometryAny]
             case .currentBiometricsOnly:
-                return [.privateKeyUsage, .biometryCurrentSet]
+                return [.privateKeyUsage, .biometryCurrentSet, .or, .devicePasscode]
             }
         }
     }

--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -11,16 +11,19 @@ public struct SecureStorageConfiguration {
 
     public enum AccessControlLevel {
         case `open`
-        case anyBiometricsOrPasscode
+        case anyBiometricsOnly
         case currentBiometricsOnly
+        case currentBiometricsOrPasscode
 
         var flags: SecAccessControlCreateFlags {
             switch self {
             case .open:
                 return []
-            case .anyBiometricsOrPasscode:
+            case .anyBiometricsOnly:
                 return [.privateKeyUsage, .biometryAny]
             case .currentBiometricsOnly:
+                return [.privateKeyUsage, .biometryCurrentSet]
+            case .currentBiometricsOrPasscode:
                 return [.privateKeyUsage, .biometryCurrentSet, .or, .devicePasscode]
             }
         }

--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -14,11 +14,15 @@ public struct SecureStorageConfiguration {
         case anyBiometricsOnly
         case currentBiometricsOnly
         case currentBiometricsOrPasscode
+        @available(*, deprecated, renamed: "anyBiometricsOnly")
+        case anyBiometricsOrPasscode
 
         var flags: SecAccessControlCreateFlags {
             switch self {
             case .open:
                 return []
+            case .anyBiometricsOrPasscode:
+                return [.privateKeyUsage, .biometryAny]
             case .anyBiometricsOnly:
                 return [.privateKeyUsage, .biometryAny]
             case .currentBiometricsOnly:

--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -17,7 +17,6 @@ public struct SecureStorageConfiguration {
         case currentBiometricsOnly
         case currentBiometricsOrPasscode
 
-
         var flags: SecAccessControlCreateFlags {
             switch self {
             case .open:

--- a/Tests/SecureStoreTests/SecureStoreConfigurationTests.swift
+++ b/Tests/SecureStoreTests/SecureStoreConfigurationTests.swift
@@ -14,6 +14,11 @@ final class SecureStoreConfigurationTests: XCTestCase {
         sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .anyBiometricsOnly)
         XCTAssertEqual(sut.accessControlLevel.flags, [.privateKeyUsage, .biometryAny])
     }
+    
+    func test_configFlags_anyBiometricsOrPasscode() throws {
+        sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .anyBiometricsOrPasscode)
+        XCTAssertEqual(sut.accessControlLevel.flags, [.privateKeyUsage, .biometryAny])
+    }
 
     func test_configFlags_currentBiometricsOnly() throws {
         sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .currentBiometricsOnly)

--- a/Tests/SecureStoreTests/SecureStoreConfigurationTests.swift
+++ b/Tests/SecureStoreTests/SecureStoreConfigurationTests.swift
@@ -1,0 +1,27 @@
+@testable import SecureStore
+import XCTest
+import LocalAuthentication
+
+final class SecureStoreConfigurationTests: XCTestCase {
+    var sut: SecureStorageConfiguration!
+
+    func test_configFlags_open() throws {
+        sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .open)
+        XCTAssertEqual(sut.accessControlLevel.flags, [])
+    }
+
+    func test_configFlags_anyBiometricsOnly() throws {
+        sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .anyBiometricsOnly)
+        XCTAssertEqual(sut.accessControlLevel.flags, [.privateKeyUsage, .biometryAny])
+    }
+
+    func test_configFlags_currentBiometricsOnly() throws {
+        sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .currentBiometricsOnly)
+        XCTAssertEqual(sut.accessControlLevel.flags, [.privateKeyUsage, .biometryCurrentSet])
+    }
+
+    func test_configFlags_currentBiometricsOrPasscode() throws {
+        sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .currentBiometricsOrPasscode)
+        XCTAssertEqual(sut.accessControlLevel.flags, [.privateKeyUsage, .biometryCurrentSet, .or, .devicePasscode])
+    }
+}

--- a/Tests/SecureStoreTests/SecureStoreConfigurationTests.swift
+++ b/Tests/SecureStoreTests/SecureStoreConfigurationTests.swift
@@ -14,7 +14,7 @@ final class SecureStoreConfigurationTests: XCTestCase {
         sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .anyBiometricsOnly)
         XCTAssertEqual(sut.accessControlLevel.flags, [.privateKeyUsage, .biometryAny])
     }
-    
+
     func test_configFlags_anyBiometricsOrPasscode() throws {
         sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .anyBiometricsOrPasscode)
         XCTAssertEqual(sut.accessControlLevel.flags, [.privateKeyUsage, .biometryAny])


### PR DESCRIPTION
# DCMAW-8006: Access secure store with device passcode

This PR is to allow users to access the secure store using the device passcode as required by [DCMAW-8006](https://govukverify.atlassian.net/browse/DCMAW-8006)

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x]  Ran the app to ensure that no regressions have been caused by changes during code review.


[DCMAW-8006]: https://govukverify.atlassian.net/browse/DCMAW-8006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ