### PR TITLE
feat: add local authentication prompt strings

### DIFF
--- a/SecureStore-Demo/SecureStore-Demo/ContentView.swift
+++ b/SecureStore-Demo/SecureStore-Demo/ContentView.swift
@@ -10,7 +10,7 @@ struct ContentView: View {
     init() {
         let localAuthStrings = [
             "localizedReason": "Local Authentication Reason",
-            "localizedFallbackTitle": "Passcode",
+            "localizedFallbackTitle": "Enter passcode",
             "localizedCancelTitle": "Cancel"
         ]
         let secureStore = SecureStoreService(configuration: .init(id: "Wallet-Test-01",

--- a/SecureStore-Demo/SecureStore-Demo/ContentView.swift
+++ b/SecureStore-Demo/SecureStore-Demo/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SecureStore
+
 struct ContentView: View {
     @State private var encryptedData: String? = ""
     @State private var myData: String = ""
@@ -8,11 +9,9 @@ struct ContentView: View {
     let secureStore: SecureStoreService
 
     init() {
-        let demoAuthStrings = [
-            "localizedReason": "Local Authentication Reason",
-            "localizedFallbackTitle": "Enter passcode",
-            "localizedCancelTitle": "Cancel"
-        ]
+        let demoAuthStrings = LocalAuthenticationLocalizedStrings(localizedReason: "Local Authentication Reason",
+                                                                  localisedFallbackTitle: "Enter passcode",
+                                                                  localisedCancelTitle: "Cancel")
         let secureStore = SecureStoreService(configuration: .init(id: "Wallet-Test-01",
                                                                   accessControlLevel: .currentBiometricsOnly,
                                                                   localAuthStrings: demoAuthStrings))

--- a/SecureStore-Demo/SecureStore-Demo/ContentView.swift
+++ b/SecureStore-Demo/SecureStore-Demo/ContentView.swift
@@ -52,8 +52,13 @@ struct ContentView: View {
                     .padding()
 
                 Button("Decrypt data") {
+                    let contextStrings = [
+                        "localizedReason": "Local Authentication Reason",
+                        "localizedFallbackTitle": "Passcode",
+                        "localizedCancelTitle": "Cancel"
+                    ]
                     do {
-                        let data = try secureStore.readItem(itemName: myData)
+                        let data = try secureStore.readItem(itemName: myData, contextStrings: contextStrings)
                         decryptedData = data
                     } catch {
                         print(error)

--- a/SecureStore-Demo/SecureStore-Demo/ContentView.swift
+++ b/SecureStore-Demo/SecureStore-Demo/ContentView.swift
@@ -8,8 +8,14 @@ struct ContentView: View {
     let secureStore: SecureStoreService
 
     init() {
+        let localAuthStrings = [
+            "localizedReason": "Local Authentication Reason",
+            "localizedFallbackTitle": "Passcode",
+            "localizedCancelTitle": "Cancel"
+        ]
         let secureStore = SecureStoreService(configuration: .init(id: "Wallet-Test-01",
-                                                                  accessControlLevel: .currentBiometricsOnly))
+                                                                  accessControlLevel: .currentBiometricsOnly,
+                                                                  localAuthStrings: localAuthStrings))
         self.secureStore = secureStore
     }
 
@@ -52,13 +58,8 @@ struct ContentView: View {
                     .padding()
 
                 Button("Decrypt data") {
-                    let contextStrings = [
-                        "localizedReason": "Local Authentication Reason",
-                        "localizedFallbackTitle": "Passcode",
-                        "localizedCancelTitle": "Cancel"
-                    ]
                     do {
-                        let data = try secureStore.readItem(itemName: myData, contextStrings: contextStrings)
+                        let data = try secureStore.readItem(itemName: myData)
                         decryptedData = data
                     } catch {
                         print(error)

--- a/SecureStore-Demo/SecureStore-Demo/ContentView.swift
+++ b/SecureStore-Demo/SecureStore-Demo/ContentView.swift
@@ -8,14 +8,14 @@ struct ContentView: View {
     let secureStore: SecureStoreService
 
     init() {
-        let localAuthStrings = [
+        let demoAuthStrings = [
             "localizedReason": "Local Authentication Reason",
             "localizedFallbackTitle": "Enter passcode",
             "localizedCancelTitle": "Cancel"
         ]
         let secureStore = SecureStoreService(configuration: .init(id: "Wallet-Test-01",
                                                                   accessControlLevel: .currentBiometricsOnly,
-                                                                  localAuthStrings: localAuthStrings))
+                                                                  localAuthStrings: demoAuthStrings))
         self.secureStore = secureStore
     }
 

--- a/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
@@ -110,7 +110,7 @@ extension SecureStoreDemoTests {
         }
 
         let decryptedString = try sut.keyManagerService
-            .decryptDataWithPrivateKey(dataToDecrypt: encryptedString, localAuthStrings: nil)
+            .decryptDataWithPrivateKey(dataToDecrypt: encryptedString)
         XCTAssertNotNil(decryptedString)
     }
 }

--- a/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
@@ -2,16 +2,14 @@ import XCTest
 @testable import SecureStore
 
 final class SecureStoreDemoTests: XCTestCase {
-    var testAuthStrings: [String: String]!
+    var testAuthStrings: LocalAuthenticationLocalizedStrings!
     var sut: SecureStoreService!
 
     override func setUp() {
         super.setUp()
-        testAuthStrings = [
-            "localizedReason": "Local Authentication Reason",
-            "localizedFallbackTitle": "Enter passcode",
-            "localizedCancelTitle": "Cancel"
-        ]
+        testAuthStrings = LocalAuthenticationLocalizedStrings(localizedReason: "Local Authentication Reason",
+                                                              localisedFallbackTitle: "Enter passcode",
+                                                              localisedCancelTitle: "Cancel")
         sut = SecureStoreService(configuration: .init(id: "id",
                                                       accessControlLevel: .open,
                                                       localAuthStrings: testAuthStrings))

--- a/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
@@ -70,10 +70,9 @@ extension SecureStoreDemoTests {
             print(error)
         }
 
-        let publicKey = try sut.keyManagerService.retrievePublicKey()
-        let privateKey = try sut.keyManagerService.retrievePrivateKey(localAuthStrings: nil)
-        XCTAssertNotNil(publicKey)
-        XCTAssertNotNil(privateKey)
+        let keys = try sut.keyManagerService.retrieveKeys()
+        XCTAssertNotNil(keys.publicKey)
+        XCTAssertNotNil(keys.privateKey)
     }
 
     func test_encryptDataWithPublicKey() throws {
@@ -83,10 +82,8 @@ extension SecureStoreDemoTests {
             print(error)
         }
 
-        let publicKey = try sut.keyManagerService.retrievePublicKey()
-        let privateKey = try sut.keyManagerService.retrievePrivateKey(localAuthStrings: nil)
-        XCTAssertNotNil(publicKey)
-        XCTAssertNotNil(privateKey)
+        let keys = try sut.keyManagerService.retrieveKeys()
+        XCTAssertNotNil(keys.publicKey)
 
         let encryptedString = try sut.keyManagerService.encryptDataWithPublicKey(dataToEncrypt: "This Data")
         XCTAssertNotNil(encryptedString)
@@ -99,10 +96,8 @@ extension SecureStoreDemoTests {
             print(error)
         }
 
-        let publicKey = try sut.keyManagerService.retrievePublicKey()
-        let privateKey = try sut.keyManagerService.retrievePrivateKey(localAuthStrings: nil)
-        XCTAssertNotNil(publicKey)
-        XCTAssertNotNil(privateKey)
+        let keys = try sut.keyManagerService.retrieveKeys()
+        XCTAssertNotNil(keys.privateKey)
 
         guard let encryptedString = try sut.keyManagerService.encryptDataWithPublicKey(dataToEncrypt: "Data") else {
             XCTFail("Failed to encrypt string")

--- a/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
@@ -7,8 +7,7 @@ final class SecureStoreDemoTests: XCTestCase {
     override func setUp() {
         super.setUp()
         sut = SecureStoreService(configuration: .init(id: "id",
-                                                      accessControlLevel: .open,
-                                                      localAuthStrings: nil))
+                                                      accessControlLevel: .open))
     }
 
     override func tearDown() {

--- a/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
@@ -7,7 +7,8 @@ final class SecureStoreDemoTests: XCTestCase {
     override func setUp() {
         super.setUp()
         sut = SecureStoreService(configuration: .init(id: "id",
-                                                      accessControlLevel: .open))
+                                                      accessControlLevel: .open,
+                                                      localAuthStrings: nil))
     }
 
     override func tearDown() {
@@ -32,7 +33,7 @@ extension SecureStoreDemoTests {
 
     func test_readItem_itemExists() throws {
         try sut.saveItem(item: "ThisItem", itemName: "ItemName")
-        XCTAssertEqual(try sut.readItem(itemName: "ItemName", contextStrings: nil), "ThisItem")
+        XCTAssertEqual(try sut.readItem(itemName: "ItemName"), "ThisItem")
     }
 
     func test_deleteItem() throws {
@@ -41,7 +42,7 @@ extension SecureStoreDemoTests {
         try sut.deleteItem(itemName: "ThisItem")
 
         do {
-            _ = try sut.readItem(itemName: "ThisItem", contextStrings: nil)
+            _ = try sut.readItem(itemName: "ThisItem")
         } catch let error as SecureStoreError where error == .unableToRetrieveFromUserDefaults {
             exp.fulfill()
         }
@@ -70,7 +71,7 @@ extension SecureStoreDemoTests {
         }
 
         let publicKey = try sut.keyManagerService.retrievePublicKey()
-        let privateKey = try sut.keyManagerService.retrievePrivateKey(contextStrings: nil)
+        let privateKey = try sut.keyManagerService.retrievePrivateKey(localAuthStrings: nil)
         XCTAssertNotNil(publicKey)
         XCTAssertNotNil(privateKey)
     }
@@ -83,7 +84,7 @@ extension SecureStoreDemoTests {
         }
 
         let publicKey = try sut.keyManagerService.retrievePublicKey()
-        let privateKey = try sut.keyManagerService.retrievePrivateKey(contextStrings: nil)
+        let privateKey = try sut.keyManagerService.retrievePrivateKey(localAuthStrings: nil)
         XCTAssertNotNil(publicKey)
         XCTAssertNotNil(privateKey)
 
@@ -99,7 +100,7 @@ extension SecureStoreDemoTests {
         }
 
         let publicKey = try sut.keyManagerService.retrievePublicKey()
-        let privateKey = try sut.keyManagerService.retrievePrivateKey(contextStrings: nil)
+        let privateKey = try sut.keyManagerService.retrievePrivateKey(localAuthStrings: nil)
         XCTAssertNotNil(publicKey)
         XCTAssertNotNil(privateKey)
 
@@ -108,7 +109,7 @@ extension SecureStoreDemoTests {
             return
         }
 
-        let decryptedString = try sut.keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedString, contextStrings: nil)
+        let decryptedString = try sut.keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedString, localAuthStrings: nil)
         XCTAssertNotNil(decryptedString)
     }
 }

--- a/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
@@ -2,16 +2,24 @@ import XCTest
 @testable import SecureStore
 
 final class SecureStoreDemoTests: XCTestCase {
+    var testAuthStrings: [String: String]!
     var sut: SecureStoreService!
 
     override func setUp() {
         super.setUp()
+        testAuthStrings = [
+            "localizedReason": "Local Authentication Reason",
+            "localizedFallbackTitle": "Enter passcode",
+            "localizedCancelTitle": "Cancel"
+        ]
         sut = SecureStoreService(configuration: .init(id: "id",
-                                                      accessControlLevel: .open))
+                                                      accessControlLevel: .open,
+                                                      localAuthStrings: testAuthStrings))
     }
 
     override func tearDown() {
         super.tearDown()
+        testAuthStrings = nil
         sut = nil
     }
 }

--- a/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
@@ -32,7 +32,7 @@ extension SecureStoreDemoTests {
 
     func test_readItem_itemExists() throws {
         try sut.saveItem(item: "ThisItem", itemName: "ItemName")
-        XCTAssertEqual(try sut.readItem(itemName: "ItemName"), "ThisItem")
+        XCTAssertEqual(try sut.readItem(itemName: "ItemName", contextStrings: nil), "ThisItem")
     }
 
     func test_deleteItem() throws {
@@ -41,7 +41,7 @@ extension SecureStoreDemoTests {
         try sut.deleteItem(itemName: "ThisItem")
 
         do {
-            _ = try sut.readItem(itemName: "ThisItem")
+            _ = try sut.readItem(itemName: "ThisItem", contextStrings: nil)
         } catch let error as SecureStoreError where error == .unableToRetrieveFromUserDefaults {
             exp.fulfill()
         }
@@ -69,9 +69,10 @@ extension SecureStoreDemoTests {
             print(error)
         }
 
-        let keys = try sut.keyManagerService.retrieveKeys()
-        XCTAssertNotNil(keys.publicKey)
-        XCTAssertNotNil(keys.privateKey)
+        let publicKey = try sut.keyManagerService.retrievePublicKey()
+        let privateKey = try sut.keyManagerService.retrievePrivateKey(contextStrings: nil)
+        XCTAssertNotNil(publicKey)
+        XCTAssertNotNil(privateKey)
     }
 
     func test_encryptDataWithPublicKey() throws {
@@ -81,8 +82,10 @@ extension SecureStoreDemoTests {
             print(error)
         }
 
-        let keys = try sut.keyManagerService.retrieveKeys()
-        XCTAssertNotNil(keys.publicKey)
+        let publicKey = try sut.keyManagerService.retrievePublicKey()
+        let privateKey = try sut.keyManagerService.retrievePrivateKey(contextStrings: nil)
+        XCTAssertNotNil(publicKey)
+        XCTAssertNotNil(privateKey)
 
         let encryptedString = try sut.keyManagerService.encryptDataWithPublicKey(dataToEncrypt: "This Data")
         XCTAssertNotNil(encryptedString)
@@ -95,15 +98,17 @@ extension SecureStoreDemoTests {
             print(error)
         }
 
-        let keys = try sut.keyManagerService.retrieveKeys()
-        XCTAssertNotNil(keys.privateKey)
+        let publicKey = try sut.keyManagerService.retrievePublicKey()
+        let privateKey = try sut.keyManagerService.retrievePrivateKey(contextStrings: nil)
+        XCTAssertNotNil(publicKey)
+        XCTAssertNotNil(privateKey)
 
         guard let encryptedString = try sut.keyManagerService.encryptDataWithPublicKey(dataToEncrypt: "Data") else {
             XCTFail("Failed to encrypt string")
             return
         }
 
-        let decryptedString = try sut.keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedString)
+        let decryptedString = try sut.keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedString, contextStrings: nil)
         XCTAssertNotNil(decryptedString)
     }
 }

--- a/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/SecureStoreDemoTests.swift
@@ -103,7 +103,8 @@ extension SecureStoreDemoTests {
             return
         }
 
-        let decryptedString = try sut.keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedString, localAuthStrings: nil)
+        let decryptedString = try sut.keyManagerService
+            .decryptDataWithPrivateKey(dataToDecrypt: encryptedString, localAuthStrings: nil)
         XCTAssertNotNil(decryptedString)
     }
 }

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -4,15 +4,15 @@ import LocalAuthentication
 class KeyManagerService {
     let defaultsStore: DefaultsStore
     private let configuration: SecureStorageConfiguration
-    
+
     public convenience init(configuration: SecureStorageConfiguration) {
         self.init(configuration: configuration, defaultsStore: UserDefaultsStore())
     }
-    
+
     init(configuration: SecureStorageConfiguration, defaultsStore: DefaultsStore) {
         self.configuration = configuration
         self.defaultsStore = defaultsStore
-        
+
         do {
             try createKeysIfNeeded(name: configuration.id)
         } catch {
@@ -26,7 +26,7 @@ extension KeyManagerService {
     // Creating a key pair where the public key is stored in the keychain
     // and the private key is stored in the Secure Enclave
     public func createKeysIfNeeded(name: String) throws {
-        
+
         // Check if keys already exist in storage
         do {
             _ = try retrieveKeys()
@@ -34,13 +34,13 @@ extension KeyManagerService {
         } catch let error as SecureStoreError where error == .cantRetrieveKey {
             // Keys do not exist yet, continue below to create and save them
         }
-        
+
         guard let access = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
                                                            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
                                                            configuration.accessControlLevel.flags,
                                                            nil),
         let tag = name.data(using: .utf8) else { return }
-        
+
         let attributes: NSDictionary = [
             kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
             kSecAttrKeySizeInBits: 256,
@@ -51,7 +51,7 @@ extension KeyManagerService {
                 kSecAttrAccessControl: access
             ]
         ]
-        
+
         var error: Unmanaged<CFError>?
         guard let privateKey = SecKeyCreateRandomKey(attributes, &error) else {
             guard let error = error?.takeRetainedValue() as? Error else {
@@ -59,15 +59,15 @@ extension KeyManagerService {
             }
             throw error
         }
-        
+
         guard let publicKey = SecKeyCopyPublicKey(privateKey) else {
             throw SecureStoreError.cantGetPublicKeyFromPrivateKey
         }
-        
+
         try storeKeys(keyToStore: publicKey, name: "\(name)PublicKey")
         try storeKeys(keyToStore: privateKey, name: "\(name)PrivateKey")
     }
-    
+
     // Store a given key to the keychain in order to reuse it later
     public func storeKeys(keyToStore: SecKey, name: String) throws {
         let key = keyToStore
@@ -75,44 +75,46 @@ extension KeyManagerService {
         let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
                                        kSecAttrApplicationTag as String: tag,
                                        kSecValueRef as String: key]
-        
+
         // Add item to KeyChain
         let status = SecItemAdd(addquery as CFDictionary, nil)
         guard status == errSecSuccess else {
             throw SecureStoreError.cantStoreKey
         }
     }
-    
+
     // Deletes a given key to the keychain
     public func deleteKeys(name: String) throws {
         let tag = name.data(using: .utf8)!
         let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
                                        kSecAttrApplicationTag as String: tag]
-        
+
         let status = SecItemDelete(addquery as CFDictionary)
         guard status == errSecSuccess else {
             throw SecureStoreError.cantStoreKey
         }
     }
-    
+
     // Retrieve a key that has been stored before
-    public func retrieveKeys(localAuthStrings: [String:String]? = nil) throws -> (publicKey: SecKey, privateKey: SecKey) {
+    public func retrieveKeys(localAuthStrings: [String: String]? = nil) throws -> (publicKey: SecKey,
+                                                                                   privateKey: SecKey) {
         guard let privateKeyTag = "\(configuration.id)PrivateKey".data(using: .utf8) else {
             throw SecureStoreError.cantInitialiseData
         }
         guard let publicKeyTag = "\(configuration.id)PublicKey".data(using: .utf8) else {
             throw SecureStoreError.cantInitialiseData
         }
-        
+
         // This constructs a query that will be sent to keychain
         var privateQuery: NSDictionary {
             if let localAuthStrings {
                 // Local Authentication prompt strings
                 let context = LAContext()
-                context.localizedReason = localAuthStrings["localizedReason"] ?? "Authenticate with local authentication"
+                context.localizedReason = localAuthStrings["localizedReason"] ??
+                "Authenticate with local authentication"
                 context.localizedFallbackTitle = localAuthStrings["localizedFallbackTitle"] ?? "Use Passcode"
                 context.localizedCancelTitle = localAuthStrings["localizedCancelTitle"] ?? "Cancel"
-                
+
                 return [
                     kSecClass: kSecClassKey,
                     kSecAttrApplicationTag: privateKeyTag,
@@ -129,15 +131,15 @@ extension KeyManagerService {
                 ]
             }
         }
-        
+
         var privateKey: CFTypeRef?
         let privateStatus = SecItemCopyMatching(privateQuery as CFDictionary, &privateKey)
-        
+
         // errSecSuccess is the result code returned when no error where found with the query
         guard privateStatus == errSecSuccess else {
             throw SecureStoreError.cantRetrieveKey
         }
-        
+
         // This constructs a query that will be sent to keychain
         let publicQuery: NSDictionary = [
             kSecClass: kSecClassKey,
@@ -145,14 +147,15 @@ extension KeyManagerService {
             kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
             kSecReturnRef: true
         ]
-        
+
         var publicKey: CFTypeRef?
         let publicStatus = SecItemCopyMatching(publicQuery as CFDictionary, &publicKey)
+
         // errSecSuccess is the result code returned when no error where found with the query
         guard publicStatus == errSecSuccess else {
             throw SecureStoreError.cantRetrieveKey
         }
-        
+
         // swiftlint:disable force_cast
         return (publicKey as! SecKey, privateKey as! SecKey)
         // swiftlint:enable force_cast
@@ -163,11 +166,11 @@ extension KeyManagerService {
 extension KeyManagerService {
     public func encryptDataWithPublicKey(dataToEncrypt: String) throws -> String? {
         let publicKey = try retrieveKeys().publicKey
-        
+
         guard let formattedData = dataToEncrypt.data(using: String.Encoding.utf8) else {
             throw SecureStoreError.cantEncryptData
         }
-        
+
         var error: Unmanaged<CFError>?
         guard let encryptData = SecKeyCreateEncryptedData(publicKey,
                                                           SecKeyAlgorithm.eciesEncryptionStandardX963SHA256AESGCM,
@@ -178,20 +181,21 @@ extension KeyManagerService {
             }
             throw error
         }
-        
+
         let encryptedData = encryptData as Data
         let encryptedString = encryptedData.base64EncodedString(options: [])
-        
+
         return encryptedString
     }
-    
-    public func decryptDataWithPrivateKey(dataToDecrypt: String, localAuthStrings: [String:String]?) throws -> String? {
+
+    public func decryptDataWithPrivateKey(dataToDecrypt: String,
+                                          localAuthStrings: [String: String]?) throws -> String? {
         let privateKeyRepresentation = try retrieveKeys(localAuthStrings: configuration.localAuthStrings).privateKey
-        
+
         guard let formattedData = Data(base64Encoded: dataToDecrypt, options: [])  else {
             throw SecureStoreError.cantDecryptData
         }
-        
+
         // Pulls from Secure Enclave - here is where we will look for FaceID/Passcode
         guard let decryptData = SecKeyCreateDecryptedData(privateKeyRepresentation,
                                                           SecKeyAlgorithm.eciesEncryptionStandardX963SHA256AESGCM,
@@ -199,11 +203,11 @@ extension KeyManagerService {
                                                           nil) else {
             throw SecureStoreError.cantDecryptData
         }
-        
+
         guard let decryptedString = String(data: decryptData as Data, encoding: String.Encoding.utf8) else {
             throw SecureStoreError.cantDecryptData
         }
-        
+
         return decryptedString
     }
 }

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -1,17 +1,11 @@
 import Foundation
 import LocalAuthentication
 
-class KeyManagerService {
-    let defaultsStore: DefaultsStore
-    private let configuration: SecureStorageConfiguration
+final class KeyManagerService {
+    let configuration: SecureStorageConfiguration
 
-    public convenience init(configuration: SecureStorageConfiguration) {
-        self.init(configuration: configuration, defaultsStore: UserDefaultsStore())
-    }
-
-    init(configuration: SecureStorageConfiguration, defaultsStore: DefaultsStore) {
+    public init(configuration: SecureStorageConfiguration) {
         self.configuration = configuration
-        self.defaultsStore = defaultsStore
 
         do {
             try createKeysIfNeeded(name: configuration.id)
@@ -25,7 +19,7 @@ class KeyManagerService {
 extension KeyManagerService {
     // Creating a key pair where the public key is stored in the keychain
     // and the private key is stored in the Secure Enclave
-    public func createKeysIfNeeded(name: String) throws {
+    func createKeysIfNeeded(name: String) throws {
 
         // Check if keys already exist in storage
         do {
@@ -69,7 +63,7 @@ extension KeyManagerService {
     }
 
     // Store a given key to the keychain in order to reuse it later
-    public func storeKeys(keyToStore: SecKey, name: String) throws {
+    func storeKeys(keyToStore: SecKey, name: String) throws {
         let key = keyToStore
         let tag = name.data(using: .utf8)!
         let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
@@ -84,7 +78,7 @@ extension KeyManagerService {
     }
 
     // Deletes a given key to the keychain
-    public func deleteKeys(name: String) throws {
+    func deleteKeys(name: String) throws {
         let tag = name.data(using: .utf8)!
         let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
                                        kSecAttrApplicationTag as String: tag]
@@ -96,8 +90,8 @@ extension KeyManagerService {
     }
 
     // Retrieve a key that has been stored before
-    public func retrieveKeys(localAuthStrings: LocalAuthenticationLocalizedStrings? = nil) throws -> (publicKey: SecKey,
-                                                                                   privateKey: SecKey) {
+    func retrieveKeys(localAuthStrings: LocalAuthenticationLocalizedStrings? = nil) throws -> (publicKey: SecKey,
+                                                                                               privateKey: SecKey) {
         guard let privateKeyTag = "\(configuration.id)PrivateKey".data(using: .utf8) else {
             throw SecureStoreError.cantInitialiseData
         }
@@ -156,7 +150,7 @@ extension KeyManagerService {
 
 // MARK: Encryption and Decryption
 extension KeyManagerService {
-    public func encryptDataWithPublicKey(dataToEncrypt: String) throws -> String? {
+    func encryptDataWithPublicKey(dataToEncrypt: String) throws -> String? {
         let publicKey = try retrieveKeys().publicKey
 
         guard let formattedData = dataToEncrypt.data(using: String.Encoding.utf8) else {
@@ -180,7 +174,7 @@ extension KeyManagerService {
         return encryptedString
     }
 
-    public func decryptDataWithPrivateKey(dataToDecrypt: String,
+    func decryptDataWithPrivateKey(dataToDecrypt: String,
                                           localAuthStrings: LocalAuthenticationLocalizedStrings?) throws -> String? {
         let privateKeyRepresentation = try retrieveKeys(localAuthStrings: configuration.localAuthStrings).privateKey
 

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -104,18 +104,16 @@ extension KeyManagerService {
         guard let publicKeyTag = "\(configuration.id)PublicKey".data(using: .utf8) else {
             throw SecureStoreError.cantInitialiseData
         }
-        
+
         // This constructs a query that will be sent to keychain
         var privateQuery: NSDictionary {
             let context = LAContext()
-            
+
             if let localAuthStrings {
                 // Local Authentication prompt strings
                 context.localizedReason = localAuthStrings.localizedReason
                 context.localizedFallbackTitle = localAuthStrings.localisedFallbackTitle
                 context.localizedCancelTitle = localAuthStrings.localisedCancelTitle
-                
-                
             }
             return [
                 kSecClass: kSecClassKey,
@@ -125,7 +123,7 @@ extension KeyManagerService {
                 kSecReturnRef: true
             ]
         }
-        
+
         var privateKey: CFTypeRef?
         let privateStatus = SecItemCopyMatching(privateQuery as CFDictionary, &privateKey)
 

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -4,7 +4,7 @@ import LocalAuthentication
 final class KeyManagerService {
     let configuration: SecureStorageConfiguration
 
-    public init(configuration: SecureStorageConfiguration) {
+    init(configuration: SecureStorageConfiguration) {
         self.configuration = configuration
 
         do {
@@ -175,7 +175,7 @@ extension KeyManagerService {
     }
 
     func decryptDataWithPrivateKey(dataToDecrypt: String,
-                                          localAuthStrings: LocalAuthenticationLocalizedStrings?) throws -> String? {
+                                   localAuthStrings: LocalAuthenticationLocalizedStrings?) throws -> String? {
         let privateKeyRepresentation = try retrieveKeys(localAuthStrings: configuration.localAuthStrings).privateKey
 
         guard let formattedData = Data(base64Encoded: dataToDecrypt, options: [])  else {

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -30,7 +30,7 @@ extension KeyManagerService {
         // Check if keys already exist in storage
         do {
             _ = try retrievePublicKey()
-            _ = try retrievePrivateKey(contextStrings: nil)
+            _ = try retrievePrivateKey(localAuthStrings: nil)
             return
         } catch let error as SecureStoreError where error == .cantRetrieveKey {
             // Keys do not exist yet, continue below to create and save them
@@ -122,18 +122,18 @@ extension KeyManagerService {
         // swiftlint:enable force_cast
     }
     
-    public func retrievePrivateKey(contextStrings: [String:String]?) throws -> SecKey {
+    public func retrievePrivateKey(localAuthStrings: [String:String]?) throws -> SecKey {
         guard let privateKeyTag = "\(configuration.id)PrivateKey".data(using: .utf8) else {
             throw SecureStoreError.cantInitialiseData
         }
         
         var privateQuery: NSDictionary {
-            if let contextStrings {
+            if let localAuthStrings {
                 // Local Authentication prompt strings
                 let context = LAContext()
-                context.localizedReason = contextStrings["localizedReason"] ?? "Authenticate with local authentication"
-                context.localizedFallbackTitle = contextStrings["localizedFallbackTitle"] ?? "Use Passcode"
-                context.localizedCancelTitle = contextStrings["localizedCancelTitle"] ?? "Cancel"
+                context.localizedReason = localAuthStrings["localizedReason"] ?? "Authenticate with local authentication"
+                context.localizedFallbackTitle = localAuthStrings["localizedFallbackTitle"] ?? "Use Passcode"
+                context.localizedCancelTitle = localAuthStrings["localizedCancelTitle"] ?? "Cancel"
                 
                 // This constructs a query that will be sent to keychain
                 return [
@@ -194,8 +194,8 @@ extension KeyManagerService {
         return encryptedString
     }
 
-    public func decryptDataWithPrivateKey(dataToDecrypt: String, contextStrings: [String:String]?) throws -> String? {
-        let privateKeyRepresentation = try retrievePrivateKey(contextStrings: contextStrings)
+    public func decryptDataWithPrivateKey(dataToDecrypt: String, localAuthStrings: [String:String]?) throws -> String? {
+        let privateKeyRepresentation = try retrievePrivateKey(localAuthStrings: localAuthStrings)
 
         guard let formattedData = Data(base64Encoded: dataToDecrypt, options: [])  else {
             throw SecureStoreError.cantDecryptData

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -78,14 +78,18 @@ extension KeyManagerService {
     }
 
     // Deletes a given key to the keychain
-    func deleteKeys(name: String) throws {
-        let tag = name.data(using: .utf8)!
-        let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
-                                       kSecAttrApplicationTag as String: tag]
+    func deleteKeys() throws {
+        let keyType = ["PublicKey", "PrivateKey"]
+        try keyType.forEach { key in
+            let keyName = configuration.id + key
+            let tag = keyName.data(using: .utf8)!
+            let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
+                                           kSecAttrApplicationTag as String: tag]
 
-        let status = SecItemDelete(addquery as CFDictionary)
-        guard status == errSecSuccess else {
-            throw SecureStoreError.cantStoreKey
+            let status = SecItemDelete(addquery as CFDictionary)
+            guard status == errSecSuccess else {
+                throw SecureStoreError.cantStoreKey
+            }
         }
     }
 
@@ -174,8 +178,7 @@ extension KeyManagerService {
         return encryptedString
     }
 
-    func decryptDataWithPrivateKey(dataToDecrypt: String,
-                                   localAuthStrings: LocalAuthenticationLocalizedStrings?) throws -> String? {
+    func decryptDataWithPrivateKey(dataToDecrypt: String) throws -> String? {
         let privateKeyRepresentation = try retrieveKeys(localAuthStrings: configuration.localAuthStrings).privateKey
 
         guard let formattedData = Data(base64Encoded: dataToDecrypt, options: [])  else {

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -4,15 +4,15 @@ import LocalAuthentication
 class KeyManagerService {
     let defaultsStore: DefaultsStore
     private let configuration: SecureStorageConfiguration
-
+    
     public convenience init(configuration: SecureStorageConfiguration) {
         self.init(configuration: configuration, defaultsStore: UserDefaultsStore())
     }
-
+    
     init(configuration: SecureStorageConfiguration, defaultsStore: DefaultsStore) {
         self.configuration = configuration
         self.defaultsStore = defaultsStore
-
+        
         do {
             try createKeysIfNeeded(name: configuration.id)
         } catch {
@@ -26,22 +26,21 @@ extension KeyManagerService {
     // Creating a key pair where the public key is stored in the keychain
     // and the private key is stored in the Secure Enclave
     public func createKeysIfNeeded(name: String) throws {
-
+        
         // Check if keys already exist in storage
         do {
-            _ = try retrievePublicKey()
-            _ = try retrievePrivateKey(localAuthStrings: nil)
+            _ = try retrieveKeys()
             return
         } catch let error as SecureStoreError where error == .cantRetrieveKey {
             // Keys do not exist yet, continue below to create and save them
         }
-
+        
         guard let access = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
                                                            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
                                                            configuration.accessControlLevel.flags,
                                                            nil),
-        let tag = name.data(using: .utf8) else { return }
-
+              let tag = name.data(using: .utf8) else { return }
+        
         let attributes: NSDictionary = [
             kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
             kSecAttrKeySizeInBits: 256,
@@ -52,7 +51,7 @@ extension KeyManagerService {
                 kSecAttrAccessControl: access
             ]
         ]
-
+        
         var error: Unmanaged<CFError>?
         guard let privateKey = SecKeyCreateRandomKey(attributes, &error) else {
             guard let error = error?.takeRetainedValue() as? Error else {
@@ -60,15 +59,15 @@ extension KeyManagerService {
             }
             throw error
         }
-
+        
         guard let publicKey = SecKeyCopyPublicKey(privateKey) else {
             throw SecureStoreError.cantGetPublicKeyFromPrivateKey
         }
-
+        
         try storeKeys(keyToStore: publicKey, name: "\(name)PublicKey")
         try storeKeys(keyToStore: privateKey, name: "\(name)PrivateKey")
     }
-
+    
     // Store a given key to the keychain in order to reuse it later
     public func storeKeys(keyToStore: SecKey, name: String) throws {
         let key = keyToStore
@@ -76,29 +75,66 @@ extension KeyManagerService {
         let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
                                        kSecAttrApplicationTag as String: tag,
                                        kSecValueRef as String: key]
-
+        
         // Add item to KeyChain
         let status = SecItemAdd(addquery as CFDictionary, nil)
         guard status == errSecSuccess else {
             throw SecureStoreError.cantStoreKey
         }
     }
-
+    
     // Deletes a given key to the keychain
     public func deleteKeys(name: String) throws {
         let tag = name.data(using: .utf8)!
         let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
                                        kSecAttrApplicationTag as String: tag]
-
+        
         let status = SecItemDelete(addquery as CFDictionary)
         guard status == errSecSuccess else {
             throw SecureStoreError.cantStoreKey
         }
     }
     
-    public func retrievePublicKey() throws -> SecKey {
+    public func retrieveKeys(localAuthStrings: [String:String]? = nil) throws -> (publicKey: SecKey, privateKey: SecKey) {
+        guard let privateKeyTag = "\(configuration.id)PrivateKey".data(using: .utf8) else {
+            throw SecureStoreError.cantInitialiseData
+        }
         guard let publicKeyTag = "\(configuration.id)PublicKey".data(using: .utf8) else {
             throw SecureStoreError.cantInitialiseData
+        }
+        
+        // This constructs a query that will be sent to keychain
+        var privateQuery: NSDictionary {
+            if let localAuthStrings {
+                // Local Authentication prompt strings
+                let context = LAContext()
+                context.localizedReason = localAuthStrings["localizedReason"] ?? "Authenticate with local authentication"
+                context.localizedFallbackTitle = localAuthStrings["localizedFallbackTitle"] ?? "Use Passcode"
+                context.localizedCancelTitle = localAuthStrings["localizedCancelTitle"] ?? "Cancel"
+                
+                return [
+                    kSecClass: kSecClassKey,
+                    kSecAttrApplicationTag: privateKeyTag,
+                    kSecUseAuthenticationContext as String: context,
+                    kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
+                    kSecReturnRef: true
+                ]
+            } else {
+                return [
+                    kSecClass: kSecClassKey,
+                    kSecAttrApplicationTag: privateKeyTag,
+                    kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
+                    kSecReturnRef: true
+                ]
+            }
+        }
+        
+        var privateKey: CFTypeRef?
+        let privateStatus = SecItemCopyMatching(privateQuery as CFDictionary, &privateKey)
+        
+        // errSecSuccess is the result code returned when no error where found with the query
+        guard privateStatus == errSecSuccess else {
+            throw SecureStoreError.cantRetrieveKey
         }
         
         // This constructs a query that will be sent to keychain
@@ -108,62 +144,16 @@ extension KeyManagerService {
             kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
             kSecReturnRef: true
         ]
-
+        
         var publicKey: CFTypeRef?
         let publicStatus = SecItemCopyMatching(publicQuery as CFDictionary, &publicKey)
-
         // errSecSuccess is the result code returned when no error where found with the query
         guard publicStatus == errSecSuccess else {
             throw SecureStoreError.cantRetrieveKey
         }
         
         // swiftlint:disable force_cast
-        return publicKey as! SecKey
-        // swiftlint:enable force_cast
-    }
-    
-    public func retrievePrivateKey(localAuthStrings: [String:String]?) throws -> SecKey {
-        guard let privateKeyTag = "\(configuration.id)PrivateKey".data(using: .utf8) else {
-            throw SecureStoreError.cantInitialiseData
-        }
-        
-        var privateQuery: NSDictionary {
-            if let localAuthStrings {
-                // Local Authentication prompt strings
-                let context = LAContext()
-                context.localizedReason = localAuthStrings["localizedReason"] ?? "Authenticate with local authentication"
-                context.localizedFallbackTitle = localAuthStrings["localizedFallbackTitle"] ?? "Use Passcode"
-                context.localizedCancelTitle = localAuthStrings["localizedCancelTitle"] ?? "Cancel"
-                
-                // This constructs a query that will be sent to keychain
-                return [
-                    kSecClass: kSecClassKey,
-                    kSecAttrApplicationTag: privateKeyTag,
-                    kSecUseAuthenticationContext as String: context,
-                    kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
-                    kSecReturnRef: true
-                ]
-            } else {
-                // This constructs a query that will be sent to keychain
-                return [
-                    kSecClass: kSecClassKey,
-                    kSecAttrApplicationTag: privateKeyTag,
-                    kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
-                    kSecReturnRef: true
-                ]
-            }
-        }
-
-        var privateKey: CFTypeRef?
-        let privateStatus = SecItemCopyMatching(privateQuery as CFDictionary, &privateKey)
-
-        // errSecSuccess is the result code returned when no error where found with the query
-        guard privateStatus == errSecSuccess else {
-            throw SecureStoreError.cantRetrieveKey
-        }
-        
-        // swiftlint:disable force_cast
-        return privateKey as! SecKey
+        return (publicKey as! SecKey, privateKey as! SecKey)
         // swiftlint:enable force_cast
     }
 }
@@ -171,12 +161,12 @@ extension KeyManagerService {
 // MARK: Encryption and Decryption
 extension KeyManagerService {
     public func encryptDataWithPublicKey(dataToEncrypt: String) throws -> String? {
-        let publicKey = try retrievePublicKey()
-
+        let publicKey = try retrieveKeys().publicKey
+        
         guard let formattedData = dataToEncrypt.data(using: String.Encoding.utf8) else {
             throw SecureStoreError.cantEncryptData
         }
-
+        
         var error: Unmanaged<CFError>?
         guard let encryptData = SecKeyCreateEncryptedData(publicKey,
                                                           SecKeyAlgorithm.eciesEncryptionStandardX963SHA256AESGCM,
@@ -187,20 +177,20 @@ extension KeyManagerService {
             }
             throw error
         }
-
+        
         let encryptedData = encryptData as Data
         let encryptedString = encryptedData.base64EncodedString(options: [])
-
+        
         return encryptedString
     }
-
+    
     public func decryptDataWithPrivateKey(dataToDecrypt: String, localAuthStrings: [String:String]?) throws -> String? {
-        let privateKeyRepresentation = try retrievePrivateKey(localAuthStrings: localAuthStrings)
-
+        let privateKeyRepresentation = try retrieveKeys(localAuthStrings: configuration.localAuthStrings).privateKey
+        
         guard let formattedData = Data(base64Encoded: dataToDecrypt, options: [])  else {
             throw SecureStoreError.cantDecryptData
         }
-
+        
         // Pulls from Secure Enclave - here is where we will look for FaceID/Passcode
         guard let decryptData = SecKeyCreateDecryptedData(privateKeyRepresentation,
                                                           SecKeyAlgorithm.eciesEncryptionStandardX963SHA256AESGCM,
@@ -208,11 +198,11 @@ extension KeyManagerService {
                                                           nil) else {
             throw SecureStoreError.cantDecryptData
         }
-
+        
         guard let decryptedString = String(data: decryptData as Data, encoding: String.Encoding.utf8) else {
             throw SecureStoreError.cantDecryptData
         }
-
+        
         return decryptedString
     }
 }

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -39,7 +39,7 @@ extension KeyManagerService {
                                                            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
                                                            configuration.accessControlLevel.flags,
                                                            nil),
-              let tag = name.data(using: .utf8) else { return }
+        let tag = name.data(using: .utf8) else { return }
         
         let attributes: NSDictionary = [
             kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
@@ -95,6 +95,7 @@ extension KeyManagerService {
         }
     }
     
+    // Retrieve a key that has been stored before
     public func retrieveKeys(localAuthStrings: [String:String]? = nil) throws -> (publicKey: SecKey, privateKey: SecKey) {
         guard let privateKeyTag = "\(configuration.id)PrivateKey".data(using: .utf8) else {
             throw SecureStoreError.cantInitialiseData

--- a/Sources/SecureStore/LocalAuthenticationLocalizedStrings.swift
+++ b/Sources/SecureStore/LocalAuthenticationLocalizedStrings.swift
@@ -1,0 +1,13 @@
+public struct LocalAuthenticationLocalizedStrings {
+    let localizedReason: String
+    let localisedFallbackTitle: String
+    let localisedCancelTitle: String
+    
+    public init(localizedReason: String,
+                localisedFallbackTitle: String,
+                localisedCancelTitle: String) {
+        self.localizedReason = localizedReason
+        self.localisedFallbackTitle = localisedFallbackTitle
+        self.localisedCancelTitle = localisedCancelTitle
+    }
+}

--- a/Sources/SecureStore/LocalAuthenticationLocalizedStrings.swift
+++ b/Sources/SecureStore/LocalAuthenticationLocalizedStrings.swift
@@ -2,7 +2,7 @@ public struct LocalAuthenticationLocalizedStrings {
     let localizedReason: String
     let localisedFallbackTitle: String
     let localisedCancelTitle: String
-    
+
     public init(localizedReason: String,
                 localisedFallbackTitle: String,
                 localisedCancelTitle: String) {

--- a/Sources/SecureStore/SecureStorable.swift
+++ b/Sources/SecureStore/SecureStorable.swift
@@ -3,7 +3,7 @@
 /// Used for saving items to keychain storage
 public protocol SecureStorable {
     func saveItem(item: String, itemName: String) throws
-    func readItem(itemName: String, contextStrings: [String:String]?) throws -> String?
+    func readItem(itemName: String) throws -> String?
     func deleteItem(itemName: String) throws
     func delete() throws
     func checkItemExists(itemName: String) throws -> Bool

--- a/Sources/SecureStore/SecureStorable.swift
+++ b/Sources/SecureStore/SecureStorable.swift
@@ -3,7 +3,7 @@
 /// Used for saving items to keychain storage
 public protocol SecureStorable {
     func saveItem(item: String, itemName: String) throws
-    func readItem(itemName: String) throws -> String?
+    func readItem(itemName: String, contextStrings: [String:String]?) throws -> String?
     func deleteItem(itemName: String) throws
     func delete() throws
     func checkItemExists(itemName: String) throws -> Bool

--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -3,11 +3,11 @@ import Foundation
 public struct SecureStorageConfiguration {
     let id: String
     let accessControlLevel: AccessControlLevel
-    let localAuthStrings: [String:String]?
+    let localAuthStrings: [String: String]?
 
     public init(id: String,
                 accessControlLevel: AccessControlLevel,
-                localAuthStrings: [String:String]? = nil) {
+                localAuthStrings: [String: String]? = nil) {
         self.id = id
         self.accessControlLevel = accessControlLevel
         self.localAuthStrings = localAuthStrings

--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -7,7 +7,7 @@ public struct SecureStorageConfiguration {
 
     public init(id: String,
                 accessControlLevel: AccessControlLevel,
-                localAuthStrings: [String:String]?) {
+                localAuthStrings: [String:String]? = nil) {
         self.id = id
         self.accessControlLevel = accessControlLevel
         self.localAuthStrings = localAuthStrings

--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -3,10 +3,14 @@ import Foundation
 public struct SecureStorageConfiguration {
     let id: String
     let accessControlLevel: AccessControlLevel
+    let localAuthStrings: [String:String]?
 
-    public init(id: String, accessControlLevel: AccessControlLevel) {
+    public init(id: String,
+                accessControlLevel: AccessControlLevel,
+                localAuthStrings: [String:String]?) {
         self.id = id
         self.accessControlLevel = accessControlLevel
+        self.localAuthStrings = localAuthStrings
     }
 
     public enum AccessControlLevel {

--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -3,11 +3,11 @@ import Foundation
 public struct SecureStorageConfiguration {
     let id: String
     let accessControlLevel: AccessControlLevel
-    let localAuthStrings: [String: String]?
+    let localAuthStrings: LocalAuthenticationLocalizedStrings?
 
     public init(id: String,
                 accessControlLevel: AccessControlLevel,
-                localAuthStrings: [String: String]? = nil) {
+                localAuthStrings: LocalAuthenticationLocalizedStrings? = nil) {
         self.id = id
         self.accessControlLevel = accessControlLevel
         self.localAuthStrings = localAuthStrings

--- a/Sources/SecureStore/SecureStoreService.swift
+++ b/Sources/SecureStore/SecureStoreService.swift
@@ -2,8 +2,8 @@ import Foundation
 import LocalAuthentication
 
 public class SecureStoreService {
-    let secureStoreDefaults: DefaultsStore
     let keyManagerService: KeyManagerService
+    let secureStoreDefaults: DefaultsStore
 
     public convenience init(configuration: SecureStorageConfiguration) {
         self.init(keyManagerService: KeyManagerService(configuration: configuration),
@@ -12,8 +12,8 @@ public class SecureStoreService {
 
     init(keyManagerService: KeyManagerService,
          defaultsStore: DefaultsStore) {
-        self.secureStoreDefaults = defaultsStore
         self.keyManagerService = keyManagerService
+        self.secureStoreDefaults = defaultsStore
     }
 }
 

--- a/Sources/SecureStore/SecureStoreService.swift
+++ b/Sources/SecureStore/SecureStoreService.swift
@@ -4,16 +4,16 @@ import LocalAuthentication
 public class SecureStoreService {
     let secureStoreDefaults: DefaultsStore
     let keyManagerService: KeyManagerService
-    private let configuration: SecureStorageConfiguration
 
     public convenience init(configuration: SecureStorageConfiguration) {
-        self.init(configuration: configuration, defaultsStore: UserDefaultsStore())
+        self.init(keyManagerService: KeyManagerService(configuration: configuration),
+                  defaultsStore: UserDefaultsStore())
     }
 
-    init(configuration: SecureStorageConfiguration, defaultsStore: DefaultsStore) {
-        self.configuration = configuration
+    init(keyManagerService: KeyManagerService,
+         defaultsStore: DefaultsStore) {
         self.secureStoreDefaults = defaultsStore
-        self.keyManagerService = KeyManagerService(configuration: configuration)
+        self.keyManagerService = keyManagerService
     }
 }
 
@@ -28,8 +28,7 @@ extension SecureStoreService: SecureStorable {
         guard let encryptedData = try secureStoreDefaults.getItem(itemName: itemName) else {
             throw SecureStoreError.unableToRetrieveFromUserDefaults
         }
-        return try keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedData,
-                                                               localAuthStrings: configuration.localAuthStrings)
+        return try keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedData)
     }
 
     public func saveItem(item: String, itemName: String) throws {
@@ -47,7 +46,6 @@ extension SecureStoreService: SecureStorable {
     }
 
     public func delete() throws {
-        try keyManagerService.deleteKeys(name: "\(configuration.id)PrivateKey")
-        try keyManagerService.deleteKeys(name: "\(configuration.id)PublicKey")
+        try keyManagerService.deleteKeys()
     }
 }

--- a/Sources/SecureStore/SecureStoreService.swift
+++ b/Sources/SecureStore/SecureStoreService.swift
@@ -13,7 +13,7 @@ public class SecureStoreService {
     init(configuration: SecureStorageConfiguration, defaultsStore: DefaultsStore) {
         self.configuration = configuration
         self.secureStoreDefaults = defaultsStore
-        self.keyManagerService = KeyManagerService(configuration: configuration, defaultsStore: defaultsStore)
+        self.keyManagerService = KeyManagerService(configuration: configuration)
     }
 }
 

--- a/Sources/SecureStore/SecureStoreService.swift
+++ b/Sources/SecureStore/SecureStoreService.swift
@@ -28,12 +28,12 @@ extension SecureStoreService: SecureStorable {
         guard let encryptedData = try secureStoreDefaults.getItem(itemName: itemName) else {
             throw SecureStoreError.unableToRetrieveFromUserDefaults
         }
-        return try keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedData, localAuthStrings: configuration.localAuthStrings)
+        return try keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedData,
+                                                               localAuthStrings: configuration.localAuthStrings)
     }
 
     public func saveItem(item: String, itemName: String) throws {
-        _ = try keyManagerService.retrievePublicKey()
-        _ = try keyManagerService.retrievePrivateKey(localAuthStrings: nil)
+        _ = try keyManagerService.retrieveKeys()
 
         guard let encryptedData = try keyManagerService.encryptDataWithPublicKey(dataToEncrypt: item) else {
             return

--- a/Sources/SecureStore/SecureStoreService.swift
+++ b/Sources/SecureStore/SecureStoreService.swift
@@ -24,16 +24,16 @@ extension SecureStoreService: SecureStorable {
         return true
     }
 
-    public func readItem(itemName: String, contextStrings: [String:String]?) throws -> String? {
+    public func readItem(itemName: String) throws -> String? {
         guard let encryptedData = try secureStoreDefaults.getItem(itemName: itemName) else {
             throw SecureStoreError.unableToRetrieveFromUserDefaults
         }
-        return try keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedData, contextStrings: contextStrings)
+        return try keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedData, localAuthStrings: configuration.localAuthStrings)
     }
 
     public func saveItem(item: String, itemName: String) throws {
         _ = try keyManagerService.retrievePublicKey()
-        _ = try keyManagerService.retrievePrivateKey(contextStrings: nil)
+        _ = try keyManagerService.retrievePrivateKey(localAuthStrings: nil)
 
         guard let encryptedData = try keyManagerService.encryptDataWithPublicKey(dataToEncrypt: item) else {
             return

--- a/Sources/SecureStore/SecureStoreService.swift
+++ b/Sources/SecureStore/SecureStoreService.swift
@@ -24,15 +24,16 @@ extension SecureStoreService: SecureStorable {
         return true
     }
 
-    public func readItem(itemName: String) throws -> String? {
+    public func readItem(itemName: String, contextStrings: [String:String]?) throws -> String? {
         guard let encryptedData = try secureStoreDefaults.getItem(itemName: itemName) else {
             throw SecureStoreError.unableToRetrieveFromUserDefaults
         }
-        return try keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedData)
+        return try keyManagerService.decryptDataWithPrivateKey(dataToDecrypt: encryptedData, contextStrings: contextStrings)
     }
 
     public func saveItem(item: String, itemName: String) throws {
-        _ = try keyManagerService.retrieveKeys()
+        _ = try keyManagerService.retrievePublicKey()
+        _ = try keyManagerService.retrievePrivateKey(contextStrings: nil)
 
         guard let encryptedData = try keyManagerService.encryptDataWithPublicKey(dataToEncrypt: item) else {
             return

--- a/Tests/SecureStoreTests/SecureStoreTests.swift
+++ b/Tests/SecureStoreTests/SecureStoreTests.swift
@@ -11,7 +11,7 @@ final class SecureStoreTests: XCTestCase {
 
         let config = SecureStorageConfiguration(id: "New_ID", accessControlLevel: .open)
 
-        sut = SecureStoreService(configuration: config,
+        sut = SecureStoreService(keyManagerService: KeyManagerService(configuration: config),
                                  defaultsStore: mockDefaultsStore)
     }
 

--- a/Tests/SecureStoreTests/SecureStoreTests.swift
+++ b/Tests/SecureStoreTests/SecureStoreTests.swift
@@ -9,7 +9,7 @@ final class SecureStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let config = SecureStorageConfiguration(id: "New_ID", accessControlLevel: .open)
+        let config = SecureStorageConfiguration(id: "New_ID", accessControlLevel: .open, localAuthStrings: nil)
 
         sut = SecureStoreService(configuration: config,
                                  defaultsStore: mockDefaultsStore)

--- a/Tests/SecureStoreTests/SecureStoreTests.swift
+++ b/Tests/SecureStoreTests/SecureStoreTests.swift
@@ -9,7 +9,7 @@ final class SecureStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let config = SecureStorageConfiguration(id: "New_ID", accessControlLevel: .open, localAuthStrings: nil)
+        let config = SecureStorageConfiguration(id: "New_ID", accessControlLevel: .open)
 
         sut = SecureStoreService(configuration: config,
                                  defaultsStore: mockDefaultsStore)


### PR DESCRIPTION
# DCMAW-6051: iOS | User returns to the app without logging in again

This PR adds the ability to pass strings displayed in the local authentication prompt when reading from the secure store.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
