### PR TITLE
fix:  undeprecate .anyBiometricsOrPasscode 

### DIFF
--- a/Sources/SecureStore/SecureStoreConfiguration.swift
+++ b/Sources/SecureStore/SecureStoreConfiguration.swift
@@ -16,7 +16,6 @@ public struct SecureStorageConfiguration {
     public enum AccessControlLevel {
         case `open`
         case anyBiometricsOnly
-        @available(*, deprecated, renamed: "anyBiometricsOnly")
         case anyBiometricsOrPasscode
         case currentBiometricsOnly
         case currentBiometricsOrPasscode
@@ -28,7 +27,7 @@ public struct SecureStorageConfiguration {
             case .anyBiometricsOnly:
                 return [.privateKeyUsage, .biometryAny]
             case .anyBiometricsOrPasscode:
-                return [.privateKeyUsage, .biometryAny]
+                return [.privateKeyUsage, .userPresence]
             case .currentBiometricsOnly:
                 return [.privateKeyUsage, .biometryCurrentSet]
             case .currentBiometricsOrPasscode:

--- a/Tests/SecureStoreTests/SecureStoreConfigurationTests.swift
+++ b/Tests/SecureStoreTests/SecureStoreConfigurationTests.swift
@@ -17,7 +17,7 @@ final class SecureStoreConfigurationTests: XCTestCase {
 
     func test_configFlags_anyBiometricsOrPasscode() throws {
         sut = SecureStorageConfiguration(id: "test_id", accessControlLevel: .anyBiometricsOrPasscode)
-        XCTAssertEqual(sut.accessControlLevel.flags, [.privateKeyUsage, .biometryAny])
+        XCTAssertEqual(sut.accessControlLevel.flags, [.privateKeyUsage, .userPresence])
     }
 
     func test_configFlags_currentBiometricsOnly() throws {


### PR DESCRIPTION


# _Title of Change_

_un-deprecate .anyBiotmetricsOrPasscode and have it use .userPresence access control to fulfill that requirement._


# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
