### PR TITLE
fix: encoding public key into JWK format

### DIFF
--- a/Sources/CryptoService/DataTypes/JWKs.swift
+++ b/Sources/CryptoService/DataTypes/JWKs.swift
@@ -1,0 +1,11 @@
+struct JWKs: Encodable {
+    let jwk: JWK
+}
+
+struct JWK: Encodable {
+    let kty = "EC"
+    let use = "sig"
+    let crv = "P-256"
+    let x: String
+    let y: String
+}

--- a/Sources/CryptoService/Encryption/CryptoEncryptionService.swift
+++ b/Sources/CryptoService/Encryption/CryptoEncryptionService.swift
@@ -20,7 +20,7 @@ public final class CryptoEncryptionService {
     }
     
     public func encryptData(dataToEncrypt: String) throws -> String {
-        guard let formattedData = dataToEncrypt.data(using: String.Encoding.utf8) else {
+        guard let formattedData = dataToEncrypt.data(using: .utf8) else {
             throw EncryptionServiceError.cantEncryptData
         }
         

--- a/Sources/CryptoService/Signing/CryptoSigningService.swift
+++ b/Sources/CryptoService/Signing/CryptoSigningService.swift
@@ -42,7 +42,6 @@ public final class CryptoSigningService: SigningService {
             return didKey
         case .jwk:
             return try generateJWK(exportedKey)
-//            throw SigningServiceError.notYetImplemented
         }
     }
     

--- a/Sources/CryptoService/Signing/CryptoSigningService.swift
+++ b/Sources/CryptoService/Signing/CryptoSigningService.swift
@@ -40,7 +40,8 @@ public final class CryptoSigningService: SigningService {
             }
             return didKey
         case .jwk:
-            throw SigningServiceError.notYetImplemented
+            return try generateJWK(exportedKey)
+//            throw SigningServiceError.notYetImplemented
         }
     }
     
@@ -50,6 +51,12 @@ public final class CryptoSigningService: SigningService {
     
     init(keyStore: KeyStore) {
         self.keyStore = keyStore
+    }
+    
+    func generateJWK(_ key: Data) throws -> Data {
+        let p256PublicKey = try P256.Signing.PublicKey(x963Representation: key)
+//        print(try JSONDecoder().decode(AppCheckJWT.self, from: p256PublicKey.JWT))
+        return try p256PublicKey.JWT
     }
     
     /// Exports the public key from the Keychain to did:key format

--- a/Sources/CryptoService/Signing/Extensions/Data.swift
+++ b/Sources/CryptoService/Signing/Extensions/Data.swift
@@ -2,13 +2,12 @@ import BigInt
 import Foundation
 
 extension Data {
+    /// Base 58 is a modified variant of base 64 which avoids:
+    ///   - non-alphanumeric characters (+ and /)
+    ///   - letters that might look ambiguous when printed:
+    ///     (0 – zero, I – capital i, O – capital o and l – lower-case L).
     func base58EncodedString() -> String {
         var bigInt = BigUInt(self)
-
-        // Base 58 is a modified variant of base 64 which avoids:
-        //   - non-alphanumeric characters (+ and /)
-        //   - letters that might look ambiguous when printed:
-        //     (0 – zero, I – capital i, O – capital o and l – lower-case L).
         let base58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
         var result = ""
 
@@ -27,10 +26,18 @@ extension Data {
         return result
     }
     
+    /// Base 64 encoding the string.
+    ///
+    /// Removing unallowed URL encoded character:
+    ///   - "="
+    ///
+    /// Replacing unallowed URL encoded characters:
+    ///   - "+" with "-"
+    ///   - "/" with "_"
     var base64URLEncodedString: String {
         base64EncodedString()
+            .replacingOccurrences(of: "=", with: "")
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
     }
 }

--- a/Sources/CryptoService/Signing/Extensions/Data.swift
+++ b/Sources/CryptoService/Signing/Extensions/Data.swift
@@ -26,4 +26,11 @@ extension Data {
         }
         return result
     }
+    
+    var base64URLEncodedString: String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
 }

--- a/Sources/CryptoService/Signing/Extensions/P256.Signing.PublicKey.swift
+++ b/Sources/CryptoService/Signing/Extensions/P256.Signing.PublicKey.swift
@@ -30,24 +30,3 @@ extension P256.Signing.PublicKey {
                    y: yCoordinateBase64)
     }
 }
-
-extension Data {
-    var base64URLEncodedString: String {
-        let base64 = self.base64EncodedString()
-        return String(base64.split(separator: "=").first!)
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-    }
-}
-
-struct JWKs: Encodable {
-    let jwk: JWK
-}
-
-struct JWK: Encodable {
-    let kty = "EC"
-    let use = "sig"
-    let crv = "P-256"
-    let x: String
-    let y: String
-}

--- a/Sources/CryptoService/Signing/Extensions/P256.Signing.PublicKey.swift
+++ b/Sources/CryptoService/Signing/Extensions/P256.Signing.PublicKey.swift
@@ -17,4 +17,33 @@ extension P256.Signing.PublicKey {
         let prefixArray = [prefix]
         return Data(prefixArray + mutableXCoordinateArrayUInt8)
     }
+    
+    var JWT: Data {
+        get throws {
+            let publicKeyUInt8 = [UInt8](x963Representation)
+            let xCoordinate = publicKeyUInt8[1...32]
+            let yCoordinate = publicKeyUInt8[33...64]
+            let xCoordinateData = Data([UInt8](xCoordinate))
+            let yCoordinateData = Data([UInt8](yCoordinate))
+            let xCoordinateBase64 = xCoordinateData.base64EncodedString()
+            let yCoordinateBase64 = yCoordinateData.base64EncodedString()
+            let appCheckJWKBody = AppCheckJWTBody(x: xCoordinateBase64,
+                                                  y: yCoordinateBase64)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            return try encoder.encode(AppCheckJWT(jwk: appCheckJWKBody))
+        }
+    }
+}
+
+struct AppCheckJWT: Encodable {
+    let jwk: AppCheckJWTBody
+}
+
+struct AppCheckJWTBody: Encodable {
+    let kty = "EC"
+    let use = "sig"
+    let crv = "P-256"
+    let x: String
+    let y: String
 }

--- a/Sources/CryptoService/Signing/Extensions/P256.Signing.PublicKey.swift
+++ b/Sources/CryptoService/Signing/Extensions/P256.Signing.PublicKey.swift
@@ -18,21 +18,16 @@ extension P256.Signing.PublicKey {
         return Data(prefixArray + mutableXCoordinateArrayUInt8)
     }
     
-    var JWT: Data {
-        get throws {
-            let publicKeyUInt8 = [UInt8](x963Representation)
-            let xCoordinate = publicKeyUInt8[1...32]
-            let yCoordinate = publicKeyUInt8[33...64]
-            let xCoordinateData = Data([UInt8](xCoordinate))
-            let yCoordinateData = Data([UInt8](yCoordinate))
-            let xCoordinateBase64 = xCoordinateData.base64URLEncodedString
-            let yCoordinateBase64 = yCoordinateData.base64URLEncodedString
-            let appCheckJWKBody = AppCheckJWTBody(x: xCoordinateBase64,
-                                                  y: yCoordinateBase64)
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            return try encoder.encode(AppCheckJWT(jwk: appCheckJWKBody))
-        }
+    var jwkRepresentation: JWK {
+        let publicKeyUInt8 = [UInt8](x963Representation)
+        let xCoordinate = publicKeyUInt8[1...32]
+        let yCoordinate = publicKeyUInt8[33...64]
+        let xCoordinateData = Data([UInt8](xCoordinate))
+        let yCoordinateData = Data([UInt8](yCoordinate))
+        let xCoordinateBase64 = xCoordinateData.base64URLEncodedString
+        let yCoordinateBase64 = yCoordinateData.base64URLEncodedString
+        return JWK(x: xCoordinateBase64,
+                   y: yCoordinateBase64)
     }
 }
 
@@ -45,11 +40,11 @@ extension Data {
     }
 }
 
-struct AppCheckJWT: Encodable {
-    let jwk: AppCheckJWTBody
+struct JWKs: Encodable {
+    let jwk: JWK
 }
 
-struct AppCheckJWTBody: Encodable {
+struct JWK: Encodable {
     let kty = "EC"
     let use = "sig"
     let crv = "P-256"

--- a/Sources/CryptoService/Signing/Extensions/P256.Signing.PublicKey.swift
+++ b/Sources/CryptoService/Signing/Extensions/P256.Signing.PublicKey.swift
@@ -25,14 +25,23 @@ extension P256.Signing.PublicKey {
             let yCoordinate = publicKeyUInt8[33...64]
             let xCoordinateData = Data([UInt8](xCoordinate))
             let yCoordinateData = Data([UInt8](yCoordinate))
-            let xCoordinateBase64 = xCoordinateData.base64EncodedString()
-            let yCoordinateBase64 = yCoordinateData.base64EncodedString()
+            let xCoordinateBase64 = xCoordinateData.base64URLEncodedString
+            let yCoordinateBase64 = yCoordinateData.base64URLEncodedString
             let appCheckJWKBody = AppCheckJWTBody(x: xCoordinateBase64,
                                                   y: yCoordinateBase64)
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             return try encoder.encode(AppCheckJWT(jwk: appCheckJWKBody))
         }
+    }
+}
+
+extension Data {
+    var base64URLEncodedString: String {
+        let base64 = self.base64EncodedString()
+        return String(base64.split(separator: "=").first!)
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
     }
 }
 

--- a/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
+++ b/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
@@ -11,11 +11,34 @@ struct CryptoSigningServiceTests {
         sut = CryptoSigningService(keyStore: keyStore)
     }
     
-    @Test
-    func publicKey_JWK() {
-        #expect(throws: SigningServiceError.notYetImplemented) {
-            try sut.publicKey(format: .jwk)
-        }
+//    @Test
+//    func publicKey_JWK() {
+//        #expect(throws: SigningServiceError.notYetImplemented) {
+//            try sut.publicKey(format: .jwk)
+//        }
+//    }
+    
+    @Test("export public key JWK format")
+    func publicKey_JWK() throws {
+        let keyString = Data("0373b3fe72bcea2cecaf2768cb85fa0bd7eb2bb91ca8918448a2ef9d323b24a188".utf8).base64EncodedString()
+        let keyData = Data(base64Encoded: keyString)!
+        let jwks = try sut.generateJWK(keyData)
+        let jwksString = String(data: jwks, encoding: .utf8)
+        #expect(jwksString == """
+            { 
+              "jwk" : {
+                "crv" : "P-256",
+                "kty" : EC",
+                "use" : "sig",
+                "x" : "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
+                "y" : "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
+              }
+            }
+        """)
+        
+//        #expect(throws: SigningServiceError.notYetImplemented) {
+//            try sut.publicKey(format: .jwk)
+//        }
     }
 
     @Test

--- a/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
+++ b/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
@@ -20,7 +20,6 @@ struct CryptoSigningServiceTests {
     @Test("Export public key in JWKs format")
     @available(iOS 16, macOS 13, *)
     func publicKey_JWKs() throws {
-        
         let key = try P256.Signing.PublicKey(pemRepresentation: """
         -----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE18wHLeIgW9wVN6VD1Txgpqy2LszY

--- a/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
+++ b/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
@@ -56,28 +56,6 @@ struct CryptoSigningServiceTests {
         )
     }
     
-//    @Test("export public key JWK format")
-//    func publicKey_JWK() throws {
-//        let keyData = Data(base64Encoded: "BDbZJ4xs5t9aF8a/xoR8XaFr74xhiqxLICQFLx9e1LykVtO1ebOWi+nPAQR9j0rkBIjdrywOFLR+qtnhTWcxgHw=")!
-//        let jwks = try sut.generateJWK(keyData)
-//        let jwksString = String(data: jwks, encoding: .utf8)
-//        #expect(jwksString == """
-//            { 
-//              "jwk" : {
-//                "crv" : "P-256",
-//                "kty" : EC",
-//                "use" : "sig",
-//                "x" : "DbZJ4xs5t9aF8a/xoR8XaFr74xhiqxLICQFLx9e1Lyk",
-//                "y" : "Ou1LmrOYh2+NTgRNa7ENRB0R9698W1k/pdMgiIqYPHU"
-//              }
-//            }
-//        """)
-//        
-//        #expect(throws: SigningServiceError.notYetImplemented) {
-//            try sut.publicKey(format: .jwk)
-//        }
-//    }
-
     @Test
     func publicKey_DID() throws {
         let didKeyString = try #require(String(data: sut.publicKey(format: .decentralisedIdentifier), encoding: .utf8))

--- a/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
+++ b/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 @testable import CryptoService
 import Foundation
 import Testing
@@ -11,35 +12,68 @@ struct CryptoSigningServiceTests {
         sut = CryptoSigningService(keyStore: keyStore)
     }
     
-//    @Test
-//    func publicKey_JWK() {
-//        #expect(throws: SigningServiceError.notYetImplemented) {
-//            try sut.publicKey(format: .jwk)
-//        }
-//    }
     
-    @Test("export public key JWK format")
-    func publicKey_JWK() throws {
-        let keyString = Data("0373b3fe72bcea2cecaf2768cb85fa0bd7eb2bb91ca8918448a2ef9d323b24a188".utf8).base64EncodedString()
-        let keyData = Data(base64Encoded: keyString)!
-        let jwks = try sut.generateJWK(keyData)
-        let jwksString = String(data: jwks, encoding: .utf8)
-        #expect(jwksString == """
+
+    @Test("Export public key in JWKs format")
+    @available(iOS 16, macOS 13, *)
+    func publicKey_JWKs() throws {
+        
+        let key = try P256.Signing.PublicKey(pemRepresentation: """
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE18wHLeIgW9wVN6VD1Txgpqy2LszY
+        kMf6J8njVAibvhP5Xh1LhRosyA//h9jiPyKvtyXVNeUV0CBzHnmjtORxIA==
+        -----END PUBLIC KEY-----
+        """)
+
+        let keyData = key.x963Representation
+        keyStore.publicKey = SecKeyCreateWithData(
+            keyData as NSData,
+            [
+                kSecAttrKeyType: kSecAttrKeyTypeEC,
+                kSecAttrKeyClass: kSecAttrKeyClassPublic
+            ] as NSDictionary,
+            nil
+        )!
+
+        let jwk = try String(data: sut.publicKey(format: .jwk), encoding: .utf8)!
+
+        #expect(
+            jwk ==
+            """
             { 
               "jwk" : {
                 "crv" : "P-256",
-                "kty" : EC",
+                "kty" : "EC",
                 "use" : "sig",
                 "x" : "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
                 "y" : "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
               }
             }
-        """)
-        
+            """
+        )
+    }
+    
+//    @Test("export public key JWK format")
+//    func publicKey_JWK() throws {
+//        let keyData = Data(base64Encoded: "BDbZJ4xs5t9aF8a/xoR8XaFr74xhiqxLICQFLx9e1LykVtO1ebOWi+nPAQR9j0rkBIjdrywOFLR+qtnhTWcxgHw=")!
+//        let jwks = try sut.generateJWK(keyData)
+//        let jwksString = String(data: jwks, encoding: .utf8)
+//        #expect(jwksString == """
+//            { 
+//              "jwk" : {
+//                "crv" : "P-256",
+//                "kty" : EC",
+//                "use" : "sig",
+//                "x" : "DbZJ4xs5t9aF8a/xoR8XaFr74xhiqxLICQFLx9e1Lyk",
+//                "y" : "Ou1LmrOYh2+NTgRNa7ENRB0R9698W1k/pdMgiIqYPHU"
+//              }
+//            }
+//        """)
+//        
 //        #expect(throws: SigningServiceError.notYetImplemented) {
 //            try sut.publicKey(format: .jwk)
 //        }
-    }
+//    }
 
     @Test
     func publicKey_DID() throws {

--- a/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
+++ b/Tests/CryptoServiceTests/CryptoSigningServiceTests.swift
@@ -5,11 +5,14 @@ import Testing
 
 struct CryptoSigningServiceTests {
     let keyStore: MockKeyStore
+    let encoder: JSONEncoder
     let sut: CryptoSigningService
 
     init() {
         keyStore = MockKeyStore()
-        sut = CryptoSigningService(keyStore: keyStore)
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        sut = CryptoSigningService(keyStore: keyStore, encoder: encoder)
     }
     
     
@@ -40,7 +43,7 @@ struct CryptoSigningServiceTests {
         #expect(
             jwk ==
             """
-            { 
+            {
               "jwk" : {
                 "crv" : "P-256",
                 "kty" : "EC",

--- a/Tests/CryptoServiceTests/Extensions/DataTests.swift
+++ b/Tests/CryptoServiceTests/Extensions/DataTests.swift
@@ -9,4 +9,16 @@ struct DataTests {
         let data = Data(bytes)
         #expect(data.base58EncodedString() == "7YXVWT")
     }
+    
+    @Test
+    func base64URLEncodedString() throws {
+        let publicKeyData = Data("""
+            BCWJzI4K0QJ60ejmwbYQ7lGg3kKDx6134c0Zn4Q7WvtobY1uIVihxougBV8/Uv417M43z60dcBJP8ojfMEQ/t+E=
+        """.utf8)
+        let urlEncoded = publicKeyData.base64URLEncodedString
+        
+        #expect(!urlEncoded.contains("="))
+        #expect(!urlEncoded.contains("+"))
+        #expect(!urlEncoded.contains("/"))
+    }
 }

--- a/Tests/CryptoServiceTests/Extensions/PublicKeyTests.swift
+++ b/Tests/CryptoServiceTests/Extensions/PublicKeyTests.swift
@@ -9,10 +9,31 @@ struct PublicKeyTests {
         let data = try #require(Data(
             base64Encoded: "BCWJzI4K0QJ60ejmwbYQ7lGg3kKDx6134c0Zn4Q7WvtobY1uIVihxougBV8/Uv417M43z60dcBJP8ojfMEQ/t+E="
         ))
+        
         let sut = try P256.Signing.PublicKey(
             x963Representation: data
         )
 
         #expect(sut.compressedRepresentation == sut._compressedRepresentation)
+    }
+    
+    @Test
+    @available(iOS 16, macOS 13, *)
+    func jwkRepresentation() throws {
+        let key = try P256.Signing.PublicKey(pemRepresentation: """
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE18wHLeIgW9wVN6VD1Txgpqy2LszY
+        kMf6J8njVAibvhP5Xh1LhRosyA//h9jiPyKvtyXVNeUV0CBzHnmjtORxIA==
+        -----END PUBLIC KEY-----
+        """)
+        
+        let constructedJWK = JWK(x: "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
+                                 y: "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA")
+        
+        #expect(key.jwkRepresentation.kty == "EC")
+        #expect(key.jwkRepresentation.use == "sig")
+        #expect(key.jwkRepresentation.crv == "P-256")
+        #expect(key.jwkRepresentation.x == constructedJWK.x)
+        #expect(key.jwkRepresentation.y == constructedJWK.y)
     }
 }


### PR DESCRIPTION
# fix: encoding public key into JWK format

The `CryptoService` module class `CryptoEncryptionService`'s `publicKey(format:)` method would throw a `SigningServiceError.notYetImplemented` error when `KeyFormat.jwk` was passed as the argument.

This PR adds the ability to retrieve the public key from the signing service in JWK format for use in cryptographic operations.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
