### PR TITLE
fix: added simulator check on secure store config

### DIFF
--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -29,9 +29,15 @@ extension KeyManagerService {
             // Keys do not exist yet, continue below to create and save them
         }
         
+        #if targetEnvironment(simulator)
+        let requirement = SecureStorageConfiguration.AccessControlLevel.open.flags
+        #else
+        let requirement = configuration.accessControlLevel.flags
+        #endif
+        
         guard let access = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
                                                            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-                                                           configuration.accessControlLevel.flags,
+                                                           requirement,
                                                            nil),
               let tag = name.data(using: .utf8) else { return }
         


### PR DESCRIPTION
# Adjusting `SecureStore` to work on simulators

Similar to on the `CryptoKeyStore`, this adds an `#if targetEnvironment(simulator)` in `CryptoService`, to the `KeyManagerService` in SecureStore.

This allows `SecureStore` to be used on Xcode simulators.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
