### PR TITLE
fix: one thousand errors mismatch

### DIFF
--- a/Sources/SecureStore/SecureStoreError/SecureStoreErrorKind.swift
+++ b/Sources/SecureStore/SecureStoreError/SecureStoreErrorKind.swift
@@ -30,8 +30,8 @@ public enum SecureStoreErrorKind: String, GDSErrorKind {
     
     case invalidatedByHandleRequest // 4
     case viewServiceInitializationFailure // 6
-    case authenticationTimedOut // -1003
     case uiActivationTimedOut // -1000
+    case authenticationTimedOut // -1003
     
     case noResultOrError
     case unknownLAError

--- a/Sources/SecureStore/SecureStoreError/SecureStoreErrorV2.swift
+++ b/Sources/SecureStore/SecureStoreError/SecureStoreErrorV2.swift
@@ -199,14 +199,14 @@ public struct GDSSecureStoreError<Kind: GDSErrorKind>: GDSError {
             )
         case LAError.Code(rawValue: -1000):
             return SecureStoreErrorV2(
-                .authenticationTimedOut,
+                .uiActivationTimedOut,
                 reason: error.localizedDescription,
                 originalError: error,
                 additionalParameters: error.userInfo
             )
         case LAError.Code(rawValue: -1003):
             return SecureStoreErrorV2(
-                .uiActivationTimedOut,
+                .authenticationTimedOut,
                 reason: error.localizedDescription,
                 originalError: error,
                 additionalParameters: error.userInfo

--- a/Tests/SecureStoreTests/SecureStoreErrorV2Tests.swift
+++ b/Tests/SecureStoreTests/SecureStoreErrorV2Tests.swift
@@ -234,23 +234,23 @@ final class SecureStoreErrorV2Tests: XCTestCase {
         )
     }
     
-    func test_authenticationTimedOutError() throws {
-        let authenticationTimedOutError = LAError(try XCTUnwrap(LAError.Code(rawValue: -1000))) as NSError
-        XCTAssertEqual(
-            SecureStoreErrorV2.biometricErrorHandling(
-                error: authenticationTimedOutError
-            ),
-            SecureStoreErrorV2(.authenticationTimedOut)
-        )
-    }
-    
     func test_uiActivationTimedOutError() throws {
-        let uiActivationTimedOutError = LAError(try XCTUnwrap(LAError.Code(rawValue: -1003))) as NSError
+        let uiActivationTimedOutError = LAError(try XCTUnwrap(LAError.Code(rawValue: -1000))) as NSError
         XCTAssertEqual(
             SecureStoreErrorV2.biometricErrorHandling(
                 error: uiActivationTimedOutError
             ),
             SecureStoreErrorV2(.uiActivationTimedOut)
+        )
+    }
+    
+    func test_authenticationTimedOutError() throws {
+        let authenticationTimedOutError = LAError(try XCTUnwrap(LAError.Code(rawValue: -1003))) as NSError
+        XCTAssertEqual(
+            SecureStoreErrorV2.biometricErrorHandling(
+                error: authenticationTimedOutError
+            ),
+            SecureStoreErrorV2(.authenticationTimedOut)
         )
     }
     


### PR DESCRIPTION
# fix: one thousand errors mismatch

Matching of errors between `1000` and `1003` was incorrect in #57.
This fix amends that mismatch.

<img width="855" height="597" alt="image 2026-02-10 at 16 07 39" src="https://github.com/user-attachments/assets/6b79dbfd-de3d-4f4f-b146-f48a7f3e79b8" />

<img width="854" height="597" alt="image 2026-02-10 at 16 07 50" src="https://github.com/user-attachments/assets/7fed8cba-f60a-491d-b6cf-f0e5a50f6ccc" />

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

~- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code~

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
