### PR TITLE
feat: DCMAW-21004 ensure no underlying errors are lost in KeyManagerService

### DIFF
--- a/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
@@ -155,4 +155,93 @@ struct KeyManagerServiceTests: ~Copyable {
         #expect(originalError.code == errSecParam)
         #expect(originalError.code == -50)
     }
+    
+    @Test("""
+            GIVEN stored key is not available (e.g. deleted)
+            WHEN retrieveKeys
+            THEN throws SecureStoreError with an original OSStatus error (e.g. OSStatus == errSecItemNotFound)
+    """)
+    func retrieveKeysSecureStoreErrorWithOriginalOSStatusError() async throws {
+        // Delete stored key
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: keyTag
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let error = #expect(throws: SecureStoreError.self) {
+            try sut.retrieveKeys()
+        }
+        
+        #expect(error?.kind == .cantRetrieveKey)
+        
+        let originalError = try #require(error?.originalError as? OSStatusError)
+        
+        #expect(originalError.status == errSecItemNotFound)
+    }
+
+    @Test("""
+            GIVEN `originalError` IS a SecureStoreError (e.g. SecureStoreError(.cantStoreKey))
+            AND **its** `originalError` IS an `OSStatus` error (e.g. errSecInteractionNotAllowed)
+            AND stored key is not available (e.g. not present),
+            WHEN retrieveKeys is called with the `originalError`
+            THEN throws SecureStoreError with an original `OSStatus` error (e.g. OSStatus == errSecItemNotFound)
+            AND the `underlyingError` is the expected `originalError`
+            AND **its** `originalError` is the expected `OSStatusError`
+    """)
+    func retrieveKeysSecureStoreErrorWithOriginalOSStatusErrorAndUnderlyingError() async throws {
+        // Delete stored key
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: keyTag
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        let originalErrorStatus: OSStatus = errSecItemNotFound
+        let initError = SecureStoreError(.cantStoreKey, originalError: OSStatusError.make(status: originalErrorStatus))
+        
+        let error = #expect(throws: SecureStoreError.self) {
+            try sut.retrieveKeys(initError: initError)
+        }
+        
+        #expect(error?.kind == .cantRetrieveKey)
+        
+        let originalError = try #require(error?.originalError as? OSStatusError)
+        #expect(originalError.status == errSecItemNotFound)
+        
+        let underlyingError = try #require(originalError.errorUserInfo[NSUnderlyingErrorKey] as? SecureStoreError)
+        #expect(underlyingError.kind == initError.kind)
+
+        let actual = try #require(underlyingError.originalError as? OSStatusError)
+        #expect(actual.status == originalErrorStatus)
+    }
+
+    @Test("""
+            GIVEN KeyManagerService did create keys
+            WHEN storePrivateKey with the same tag
+            THEN throws SecureStoreError(.cantStoreKey) with an original OSStatus error (e.g. OSStatus == errSecDuplicateItem)
+    """)
+    func attemptStorePrivateKeyThrowsCantStoreKeyWitherrSecDuplicateItem() async throws {
+        let tag = "\(testRunID)PrivateKey"
+        let attributes: NSDictionary = [
+            kSecAttrKeyType: kSecAttrKeyTypeRSA,
+            kSecAttrKeySizeInBits: 2048,
+            kSecPrivateKeyAttrs: [
+                kSecAttrIsPermanent: true,
+                kSecAttrApplicationTag: tag
+            ]
+        ]
+
+        let anyKey = try #require(SecKeyCreateRandomKey(attributes, nil))
+
+        let error = #expect(throws: SecureStoreError.self) {
+            try sut.storePrivateKey(keyToStore: anyKey, name: tag)
+        }
+
+        #expect(error?.kind == .cantStoreKey)
+
+        let originalError = try #require(error?.originalError as? OSStatusError)
+
+        #expect(originalError.status == errSecDuplicateItem)
+    }
 }

--- a/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
@@ -222,7 +222,7 @@ struct KeyManagerServiceTests: ~Copyable {
             THEN throws SecureStoreError(.cantStoreKey) with an original OSStatus error (e.g. OSStatus == errSecDuplicateItem)
     """)
     func attemptStorePrivateKeyThrowsCantStoreKeyWitherrSecDuplicateItem() async throws {
-        let tag = "\(testRunID)PrivateKey"
+        let tag = "\(testRunID)"
         let attributes: NSDictionary = [
             kSecAttrKeyType: kSecAttrKeyTypeRSA,
             kSecAttrKeySizeInBits: 2048,

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -3,6 +3,7 @@ import LocalAuthentication
 
 final class KeyManagerService {
     let configuration: SecureStorageConfiguration
+    var initError: Error?
     
     init(configuration: SecureStorageConfiguration) {
         self.configuration = configuration
@@ -10,6 +11,7 @@ final class KeyManagerService {
         do {
             try createKeysIfNeeded(name: configuration.id)
         } catch {
+            self.initError = error
             return
         }
     }
@@ -35,11 +37,17 @@ extension KeyManagerService {
         let requirement = configuration.accessControlLevel.flags
         #endif
         
+        var accessControlCreateWithFlagsError: Unmanaged<CFError>?
         guard let access = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
                                                            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
                                                            requirement,
-                                                           nil),
-              let tag = name.data(using: .utf8) else { return }
+                                                           &accessControlCreateWithFlagsError),
+              let tag = name.data(using: .utf8) else {
+            guard let error = accessControlCreateWithFlagsError?.takeRetainedValue() as? Error else {
+                throw SecureStoreError(.noResultOrError)
+            }
+            throw error
+        }
         
         let attributes: NSDictionary = [
             kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
@@ -74,7 +82,7 @@ extension KeyManagerService {
         // Add item to KeyChain
         let status = SecItemAdd(addquery as CFDictionary, nil)
         guard status == errSecSuccess else {
-            throw SecureStoreError(.cantStoreKey)
+            throw SecureStoreError(.cantStoreKey, originalError: OSStatusError.make(status: status, underlyingError: self.initError))
         }
     }
     
@@ -89,13 +97,21 @@ extension KeyManagerService {
             
             let status = SecItemDelete(deleteQuery as CFDictionary)
             guard status == errSecSuccess || status == errSecItemNotFound else {
-                throw SecureStoreError(.cantDeleteKey)
+                throw SecureStoreError(.cantDeleteKey, originalError: OSStatusError.make(status: status, underlyingError: self.initError))
             }
         }
     }
     
-    // Retrieve a key that has been stored before
-    func retrieveKeys(localAuthStrings: LocalAuthenticationLocalizedStrings? = nil) throws -> (publicKey: SecKey,
+    /// Retrieve the key stored under ``SecureStorageConfiguration/id``+"PrivateKey".
+    ///
+    /// - Parameters:
+    ///     - localAuthStrings: optional; in case your code expects the user to be prompted and need to provide a
+    ///         `localizedReason`,   `localizedFallbackTitle` and `localizedCancelTitle`; default `nil`
+    ///     - initError: optional, in case your code needs to also record the underlying error raised when this
+    ///         ``KeyManagerService`` was ``init( configuration:)``,  pass the error (i.e. ``self.initError``)
+    /// - throws: ``SecureStoreError(.cantRetrieveKey)`` in case either the private or its corresponding public key cannot be retrieved;
+    ///     the "root underlying error" error holds the value of the error passed in as `initError`
+    func retrieveKeys(localAuthStrings: LocalAuthenticationLocalizedStrings? = nil, initError: Error? = nil) throws -> (publicKey: SecKey,
                                                                                                privateKey: SecKey) {
         let privateKeyTag = Data("\(configuration.id)PrivateKey".utf8)
         
@@ -123,7 +139,7 @@ extension KeyManagerService {
 
         // errSecSuccess is the result code returned when no error was found with the query
         guard privateStatus == errSecSuccess else {
-            throw SecureStoreError(.cantRetrieveKey)
+            throw SecureStoreError(.cantRetrieveKey, originalError: OSStatusError.make(status: privateStatus, underlyingError: initError))
         }
 
         // swiftlint:disable force_cast
@@ -131,7 +147,7 @@ extension KeyManagerService {
         // swiftlint:enable force_cast
         
         guard let publicKey = SecKeyCopyPublicKey(privateKey) else {
-            throw SecureStoreError(.cantRetrieveKey)
+            throw SecureStoreError(.cantRetrieveKey, originalError: initError)
         }
 
         return (publicKey, privateKey)
@@ -141,10 +157,10 @@ extension KeyManagerService {
 // MARK: Encryption and Decryption
 extension KeyManagerService {
     func encryptDataWithPublicKey(dataToEncrypt: String) throws -> String {
-        let publicKey = try retrieveKeys().publicKey
+        let publicKey = try retrieveKeys(initError: self.initError).publicKey
         
         guard let formattedData = dataToEncrypt.data(using: .utf8) else {
-            throw SecureStoreError(.cantEncodeData)
+            throw SecureStoreError(.cantEncodeData, originalError: self.initError)
         }
         
         var error: Unmanaged<CFError>?
@@ -170,7 +186,8 @@ extension KeyManagerService {
         let privateKeyRepresentation: SecKey
         do {
             privateKeyRepresentation = try retrieveKeys(
-                localAuthStrings: configuration.localAuthStrings
+                localAuthStrings: configuration.localAuthStrings,
+                initError: self.initError
             ).privateKey
         } catch {
             throw SecureStoreError(
@@ -181,7 +198,7 @@ extension KeyManagerService {
         }
         
         guard let formattedData = Data(base64Encoded: dataToDecrypt)  else {
-            throw SecureStoreError(.cantFormatData)
+            throw SecureStoreError(.cantFormatData, originalError: self.initError)
         }
         
         var error: Unmanaged<CFError>?
@@ -202,7 +219,7 @@ extension KeyManagerService {
             data: decryptData as Data,
             encoding: .utf8
         ) else {
-            throw SecureStoreError(.cantDecodeData)
+            throw SecureStoreError(.cantDecodeData, originalError: self.initError)
         }
         
         return decryptedString

--- a/Sources/SecureStore/OSStatusError.swift
+++ b/Sources/SecureStore/OSStatusError.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct OSStatusError: CustomNSError, CustomDebugStringConvertible {
+    static func make(status: OSStatus, underlyingError: Error? = nil) -> Self {
+    
+        var errorUserInfo: [String: any Sendable] = [:]
+        
+        if let errorMessage = SecCopyErrorMessageString(status, nil) {
+            errorUserInfo[NSDebugDescriptionErrorKey] = errorMessage as String
+        }
+        
+        if let underlyingError {
+            errorUserInfo[NSUnderlyingErrorKey] = underlyingError
+        }
+        
+        return OSStatusError(status: status, _errorUserInfo: errorUserInfo)
+    }
+    
+    let status: OSStatus
+    private let _errorUserInfo: [String: any Sendable]
+    
+    // MARK: CustomNSError
+    static var errorDomain: String {
+        NSOSStatusErrorDomain
+    }
+    
+    var errorCode: Int {
+        return Int(status)
+    }
+    
+    var errorUserInfo: [String: Any] {
+        _errorUserInfo
+    }
+    
+    // MARK: CustomDebugStringConvertible
+    
+    var debugDescription: String {
+        return errorUserInfo[NSDebugDescriptionErrorKey] as? String ?? ""
+    }
+}

--- a/Tests/SecureStoreTests/OSStatusErrorTests.swift
+++ b/Tests/SecureStoreTests/OSStatusErrorTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+@testable import SecureStore
+import Security
+import Testing
+
+struct OSStatusErrorTests {
+
+    @Test func makeKeyManagerServiceError() async throws {
+        let anyStatus: OSStatus = errSecItemNotFound
+        let error: OSStatusError = .make(status: anyStatus)
+        
+        #expect(OSStatusError.errorDomain == NSOSStatusErrorDomain)
+        #expect(error.errorCode == anyStatus)
+    }
+
+    @Test func underLyingError() async throws {
+        let anyStatus: OSStatus = errSecItemNotFound
+        let anyError: NSError = .init(domain: "any", code: 1)
+        let error: OSStatusError = .make(status: anyStatus, underlyingError: anyError)
+        
+        let actualUnderLyingError = try #require(error.errorUserInfo[NSUnderlyingErrorKey] as? NSError)
+        #expect(actualUnderLyingError == anyError)
+    }
+
+    /// Asserts that the debugDescription, as it is computed by a GDSError (i.e. SecureStoreError),
+    /// includes the debug description found in a non-GDSError that is instead a CustomNSError (i.e. KeyManagerServiceError)
+    /// when the non-GDSError is the `originalError`.
+    @Test
+    func secureStoreErrorWithDebugDescriptionGivenOSStatusWithWithErrorMessageString() async throws {
+        let errSecItemNotFound: OSStatus = errSecItemNotFound
+        let errSecItemNotFoundDebugDescriptionExpected = "The specified item could not be found in the keychain."
+        
+        let error: OSStatusError = .make(status: errSecItemNotFound)
+        let anySecureStoreError = SecureStoreError(.cantRetrieveKey, originalError: error)
+        
+        #expect(anySecureStoreError.debugDescription == "Error while retrieving key from the keychain - (\(errSecItemNotFoundDebugDescriptionExpected))")
+    }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,6 +12,9 @@ sonar.exclusions=Tests/**,Tests/**/**/*,Tests/CryptoServiceTests/Mocks/*
 sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=swift:S1479
 sonar.issue.ignore.multicriteria.e1.resourceKey=Sources/SecureStore/SecureStoreError/SecureStoreErrorKind.swift
+sonar.issue.ignore.multicriteria=e2
+sonar.issue.ignore.multicriteria.e2.ruleKey=swift:S115
+sonar.issue.ignore.multicriteria.e2.resourceKey=Sources/SecureStore/OSStatusError.swift
 
 sonar.language=swift
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
# [Ensure no underlying errors are lost in KeyManagerService](https://govukverify.atlassian.net/browse/DCMAW-21004)

> [!NOTE]
> This is a change required to support the work done for [iOS | Tech Debt | SecureStoreError(.cantRetrieveKey) | KeyManagerService](https://govukverify.atlassian.net/browse/DCMAW-21004) 

This code change ensures that:
    * Any error thrown as part of initialising a new instance of KeyManagerService is not lost
    * Any errors raised by the Security framework (e.g. Keychain) are captured as `originalError` in any `SecureStoreError` thrown.

# Changes

The proposed change, first and foremost, is intended to improve logging and diagnostics. As of today, we’ve had instances where operations fail (e.g. encrypting a string) without visibility to the underlying error(s).

# Where to focus the review

* Is error propagation correct? Is the test coverage sufficient or do you think there is a case missing?
* Previously, the error returned by `SecAccessControlCreateWithFlags` was ignored and the function return; which could leave the `KeyManagerService` in an invalid state. This PR makes a change to instead throw in case of an error.
* In case `retrieveKeys()` throws a `SecureStoreError where error.kind == .cantRetrieveKey`, the error is gone missing. I am not sure how to handle this case. Thoughts? See `// Keys do not exist yet, continue below to create and save them`

# Discussion

Note: The specific implementation (I.e. to keep a reference to the error rather than throw) in KeyManager.init() on how an error thrown by `createKeysIfNeeded(name:)` is reported was made having 2 things in mind:
* Avoid breaking changes to the public API of KeyManager
* Not being able to recommend a solution in case an error is thrown

This should be considered an interim solution and the least worst option at this time as opposed to a long term solution. For once, this code should fail early, instead of failing at a later time (e.g. attempting to encrypt data). Secondly, this may leave the KeyManager in an invalid state from which it’s not possible to recover.


# Notable Additions

This commit introduces the `OSStatusError` type that is meant to represent any error generated by the Security framework in the form of a `OSStatus`. 

# Do not merge

Depends on PRs:

* https://github.com/govuk-one-login/mobile-ios-utilities/pull/18
* https://github.com/govuk-one-login/mobile-ios-secure-store/pull/69

# Future Considerations

This PR does not address the case of a `SecureStoreError(.cantRetrieveKey)` as described in the ticket. With the logging available it was a futile exercise. Hence this PR merely improves the logging of any underlying errors. 

Some future considerations:
* Address the root issue behind the case of `SecureStoreError(.cantRetrieveKey)` as described in the ticket
* Separate the creation of a KeyManager and the creation of keys.
* * Create an instance of a KeyManager in order to be able to build the object graph without any errors and not risk leaving the KeyManager in an invalid state
* * Create the keys, if needed, as a function to be called outside the initialiser. This leaves a chance to the calling code to handle the error as soon as possible and potentially be in a better place to recover.

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
