### PR TITLE
feat: DCMAW-21030 increased test coverage

### DIFF
--- a/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LocalAuthentication
 @testable import SecureStore
 import Testing
 
@@ -63,5 +64,95 @@ struct KeyManagerServiceTests: ~Copyable {
 
         let publicKey = try #require(SecKeyCopyPublicKey(privateKey))
         #expect(keys.publicKey == publicKey)
+    }
+
+    /// This is a case where a as part of instantiating a `KeyManagerService`, a new set of keys is created
+    /// that is tied to the Secure Enclave (i.e. `kSecAttrTokenID: kSecAttrTokenIDSecureEnclave`).
+    ///
+    /// The keys are explicitly deleted by calling `deleteKeys()` in the  `KeyManagerService`
+    ///
+    /// When attempting to **decrypt** the data, an `errSecParam` (aka -50) will be thrown
+    @Test("""
+            GIVEN a new `KeyManagerService` with a set of keys
+            AND a data is encrypted
+            AND the keys are explicitly deleted
+            AND a new `KeyManagerService` is created with the same (i.e. same `id`) configuration
+            WHEN attempting to decrypt the data
+            THEN throws `SecureStoreError.cantDecryptData`
+            AND the `originalError` is `errSecParam` (i.e. -50 OSStatus)
+    """)
+    func decryptKeyWithWrongPrivateKey() async throws {
+
+        let anyString = "any"
+        let encrypted = try sut.encryptDataWithPublicKey(dataToEncrypt: anyString)
+                
+        try sut.deleteKeys()
+
+        let sut = KeyManagerService(configuration: .init(
+            id: testRunID.uuidString,
+            accessControlLevel: .open
+        ))
+
+        let error = #expect(throws: SecureStoreError.self) {
+            try sut.decryptDataWithPrivateKey(dataToDecrypt: encrypted)
+        }
+        
+        #expect(error?.kind == .cantDecryptData)
+        
+        let originalError = try #require(error?.originalError as? NSError)
+        #expect(originalError.code == errSecParam)
+        #expect(originalError.code == -50)
+    }
+    
+    /// This is a case where a as part of instantiating a `KeyManagerService`, a new set of keys is created
+    /// that is tied to the Secure Enclave (i.e. `kSecAttrTokenID: kSecAttrTokenIDSecureEnclave`).
+    ///
+    /// A SE key pair provides strong guarantees so that:
+    /// * It is never exported to a backup
+    /// * The key pair is deleted as soon as the device is erased
+    ///
+    /// In this case:
+    /// 1. a backup from an existing device, with previously encrypted data, was taken
+    /// 2. a restore on the device is performed
+    /// 3. the data is restored
+    /// 4. the key is not restored
+    ///
+    /// When attempting to **decrypt** the data, an `errSecParam` (aka -50) will be thrown
+    @Test("""
+            GIVEN a new `KeyManagerService` with a set of keys
+            AND a data is encrypted
+            AND the key is deleted due (e.g. due to a device erase)
+            AND a new `KeyManagerService` is created with the same (i.e. same `id`) configuration as part of a new app installation
+            WHEN attempting to decrypt the existing, previously backed-up, data
+            THEN throws `SecureStoreError.cantDecryptData`
+            AND the `originalError` is `errSecParam` (i.e. -50 OSStatus)
+    """)
+    func decryptKeyWithWrongPrivateKeyDueToOriginalKeyGoneMising() async throws {
+
+        let anyString = "any"
+        let encrypted = try sut.encryptDataWithPublicKey(dataToEncrypt: anyString)
+        
+        // Device Erased
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassKey,
+            kSecAttrApplicationTag as String: keyTag
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+        
+        // New app installation
+        let sut = KeyManagerService(configuration: .init(
+            id: testRunID.uuidString,
+            accessControlLevel: .open
+        ))
+
+        let error = #expect(throws: SecureStoreError.self) {
+            try sut.decryptDataWithPrivateKey(dataToDecrypt: encrypted)
+        }
+        
+        #expect(error?.kind == .cantDecryptData)
+        
+        let originalError = try #require(error?.originalError as? NSError)
+        #expect(originalError.code == errSecParam)
+        #expect(originalError.code == -50)
     }
 }


### PR DESCRIPTION
# [iOS | Tech Debt | SecureStoreError(.cantDecryptData) | NSOStatusErrorDomain (-50) | KeyManagerService](https://govukverify.atlassian.net/browse/DCMAW-21030)

> [!NOTE]
> This PR does not make any changes to the source code. 

Adds test cases of errSecParam (i.e. -50) error

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [ ] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [ ] Met all of the acceptance criteria specified in the user story on Jira
- [ ] Reviewed your own code to ensure you are following the style guidelines
- [ ] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [ ] Written Unit and Integration tests if needed

- [ ] Met all accessibility requirements?
    - [ ] Checked dynamic type sizes are applied
    - [ ] Checked VoiceOver can navigate your new code
    - [ ] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [ ] Ensure that the code coverage and SonarCloud checks have passed
- [ ] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [ ] Ran the app to ensure that no regressions have been caused by changes during code review.
