### PR TITLE
feat: DCMAW-21042 remove duplicate key from being created

### DIFF
--- a/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
@@ -3,7 +3,7 @@ import LocalAuthentication
 @testable import SecureStore
 import Testing
 
-@Suite
+@Suite(.serialized)
 struct KeyManagerServiceTests: ~Copyable {
     private let testRunID = UUID()
     private let sut: KeyManagerService
@@ -25,7 +25,6 @@ struct KeyManagerServiceTests: ~Copyable {
 
     @Test("When initialised, KeyManagerService creates private key and stores this in keychain")
     func createsKeyOnInitialisation() async throws {
-
         let query = NSDictionary(dictionary: [
             kSecClass: kSecClassKey,
             kSecAttrApplicationTag: keyTag,
@@ -65,6 +64,61 @@ struct KeyManagerServiceTests: ~Copyable {
         let publicKey = try #require(SecKeyCopyPublicKey(privateKey))
         #expect(keys.publicKey == publicKey)
     }
+    
+    @Test("There should only be 1 private key generated")
+    func checkNumberofGeneratedKeysIsOne() async throws {
+        // delete all keys from previous tests
+        let deleteQuery: [String: Any] = [kSecClass as String: kSecClassKey]
+        let _ = SecItemDelete(deleteQuery as CFDictionary)
+        
+        // creates private key
+        let _ = KeyManagerService(configuration: .init(
+            id: testRunID.uuidString,
+            accessControlLevel: .open
+        ))
+
+        let query = NSDictionary(dictionary: [
+            kSecClass: kSecClassKey,
+            kSecMatchLimit: kSecMatchLimitAll,
+            kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecReturnRef: true
+        ])
+
+        var privateKeyRef: CFTypeRef?
+        let _ = SecItemCopyMatching(query as CFDictionary, &privateKeyRef)
+        let array = try #require(privateKeyRef as? Array<SecKey>)
+
+        // No duplicate keys created
+        #expect(array.count == 1)
+    }
+    
+    @Test("Make sure there are no keys remaining in the keychain after deleting")
+    func checkDeleteKeysDeletesAllKeysWithNoRemaining() async throws {
+        // delete all keys from previous tests
+        let deleteQuery: [String: Any] = [kSecClass as String: kSecClassKey]
+        let _ = SecItemDelete(deleteQuery as CFDictionary)
+        
+        // creates private key
+        let _ = KeyManagerService(configuration: .init(
+            id: testRunID.uuidString,
+            accessControlLevel: .open
+        ))
+
+        try sut.deleteKeys()
+        
+        let query = NSDictionary(dictionary: [
+            kSecClass: kSecClassKey,
+            kSecMatchLimit: kSecMatchLimitAll,
+            kSecAttrKeyType: kSecAttrKeyTypeECSECPrimeRandom,
+            kSecReturnRef: true
+        ])
+
+        var privateKeyRef: CFTypeRef?
+        let _ = SecItemCopyMatching(query as CFDictionary, &privateKeyRef)
+
+        // No keys in the keychain returns nil
+        #expect(privateKeyRef == nil)
+    }
 
     /// This is a case where a as part of instantiating a `KeyManagerService`, a new set of keys is created
     /// that is tied to the Secure Enclave (i.e. `kSecAttrTokenID: kSecAttrTokenIDSecureEnclave`).
@@ -82,7 +136,6 @@ struct KeyManagerServiceTests: ~Copyable {
             AND the `originalError` is `errSecParam` (i.e. -50 OSStatus)
     """)
     func decryptKeyWithWrongPrivateKey() async throws {
-
         let anyString = "any"
         let encrypted = try sut.encryptDataWithPublicKey(dataToEncrypt: anyString)
                 
@@ -128,7 +181,6 @@ struct KeyManagerServiceTests: ~Copyable {
             AND the `originalError` is `errSecParam` (i.e. -50 OSStatus)
     """)
     func decryptKeyWithWrongPrivateKeyDueToOriginalKeyGoneMising() async throws {
-
         let anyString = "any"
         let encrypted = try sut.encryptDataWithPublicKey(dataToEncrypt: anyString)
         

--- a/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
@@ -69,10 +69,10 @@ struct KeyManagerServiceTests: ~Copyable {
     func checkNumberofGeneratedKeysIsOne() async throws {
         // delete all keys from previous tests
         let deleteQuery: [String: Any] = [kSecClass as String: kSecClassKey]
-        let _ = SecItemDelete(deleteQuery as CFDictionary)
+        _ = SecItemDelete(deleteQuery as CFDictionary)
         
         // creates private key
-        let _ = KeyManagerService(configuration: .init(
+        _ = KeyManagerService(configuration: .init(
             id: testRunID.uuidString,
             accessControlLevel: .open
         ))
@@ -85,8 +85,8 @@ struct KeyManagerServiceTests: ~Copyable {
         ])
 
         var privateKeyRef: CFTypeRef?
-        let _ = SecItemCopyMatching(query as CFDictionary, &privateKeyRef)
-        let array = try #require(privateKeyRef as? Array<SecKey>)
+        _ = SecItemCopyMatching(query as CFDictionary, &privateKeyRef)
+        let array = try #require(privateKeyRef as? [SecKey])
 
         // No duplicate keys created
         #expect(array.count == 1)
@@ -96,10 +96,10 @@ struct KeyManagerServiceTests: ~Copyable {
     func checkDeleteKeysDeletesAllKeysWithNoRemaining() async throws {
         // delete all keys from previous tests
         let deleteQuery: [String: Any] = [kSecClass as String: kSecClassKey]
-        let _ = SecItemDelete(deleteQuery as CFDictionary)
+        _ = SecItemDelete(deleteQuery as CFDictionary)
         
         // creates private key
-        let _ = KeyManagerService(configuration: .init(
+        _ = KeyManagerService(configuration: .init(
             id: testRunID.uuidString,
             accessControlLevel: .open
         ))
@@ -114,7 +114,7 @@ struct KeyManagerServiceTests: ~Copyable {
         ])
 
         var privateKeyRef: CFTypeRef?
-        let _ = SecItemCopyMatching(query as CFDictionary, &privateKeyRef)
+        _ = SecItemCopyMatching(query as CFDictionary, &privateKeyRef)
 
         // No keys in the keychain returns nil
         #expect(privateKeyRef == nil)

--- a/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
@@ -9,7 +9,7 @@ struct KeyManagerServiceTests: ~Copyable {
     private let sut: KeyManagerService
 
     private var keyTag: Data {
-        Data("\(testRunID)PrivateKey".utf8)
+        Data("\(testRunID)".utf8)
     }
 
     init() {

--- a/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
+++ b/SecureStore-Demo/SecureStore-DemoTests/KeyManagerServiceTests.swift
@@ -267,33 +267,4 @@ struct KeyManagerServiceTests: ~Copyable {
         let actual = try #require(underlyingError.originalError as? OSStatusError)
         #expect(actual.status == originalErrorStatus)
     }
-
-    @Test("""
-            GIVEN KeyManagerService did create keys
-            WHEN storePrivateKey with the same tag
-            THEN throws SecureStoreError(.cantStoreKey) with an original OSStatus error (e.g. OSStatus == errSecDuplicateItem)
-    """)
-    func attemptStorePrivateKeyThrowsCantStoreKeyWitherrSecDuplicateItem() async throws {
-        let tag = "\(testRunID)"
-        let attributes: NSDictionary = [
-            kSecAttrKeyType: kSecAttrKeyTypeRSA,
-            kSecAttrKeySizeInBits: 2048,
-            kSecPrivateKeyAttrs: [
-                kSecAttrIsPermanent: true,
-                kSecAttrApplicationTag: tag
-            ]
-        ]
-
-        let anyKey = try #require(SecKeyCreateRandomKey(attributes, nil))
-
-        let error = #expect(throws: SecureStoreError.self) {
-            try sut.storePrivateKey(keyToStore: anyKey, name: tag)
-        }
-
-        #expect(error?.kind == .cantStoreKey)
-
-        let originalError = try #require(error?.originalError as? OSStatusError)
-
-        #expect(originalError.status == errSecDuplicateItem)
-    }
 }

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -59,28 +59,11 @@ extension KeyManagerService {
             }
             throw error
         }
-
-        try storePrivateKey(keyToStore: privateKey, name: "\(name)PrivateKey")
-    }
-    
-    // Store a given key to the keychain in order to reuse it later
-    func storePrivateKey(keyToStore: SecKey, name: String) throws {
-        let key = keyToStore
-        let tag = name.data(using: .utf8)!
-        let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
-                                       kSecAttrApplicationTag as String: tag,
-                                       kSecValueRef as String: key]
-        
-        // Add item to KeyChain
-        let status = SecItemAdd(addquery as CFDictionary, nil)
-        guard status == errSecSuccess else {
-            throw SecureStoreError(.cantStoreKey)
-        }
     }
     
     // Deletes a given key to the keychain
     func deleteKeys() throws {
-        let keyType = ["PublicKey", "PrivateKey"]
+        let keyType = ["PublicKey", "PrivateKey", ""]
         try keyType.forEach { key in
             let keyName = configuration.id + key
             let tag = keyName.data(using: .utf8)!
@@ -97,7 +80,7 @@ extension KeyManagerService {
     // Retrieve a key that has been stored before
     func retrieveKeys(localAuthStrings: LocalAuthenticationLocalizedStrings? = nil) throws -> (publicKey: SecKey,
                                                                                                privateKey: SecKey) {
-        let privateKeyTag = Data("\(configuration.id)PrivateKey".utf8)
+        let privateKeyTag = Data("\(configuration.id)".utf8)
         
         // This constructs a query that will be sent to keychain
         var privateQuery: NSDictionary {

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -85,7 +85,7 @@ extension KeyManagerService {
         }
     }
     
-    /// Retrieve the key stored under ``SecureStorageConfiguration/id``+"PrivateKey".
+    /// Retrieve the key stored under ``SecureStorageConfiguration/id``
     ///
     /// - Parameters:
     ///     - localAuthStrings: optional; in case your code expects the user to be prompted and need to provide a

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -53,7 +53,7 @@ extension KeyManagerService {
         ]
         
         var error: Unmanaged<CFError>?
-        guard let privateKey = SecKeyCreateRandomKey(attributes, &error) else {
+        guard let _ = SecKeyCreateRandomKey(attributes, &error) else {
             guard let error = error?.takeRetainedValue() as? Error else {
                 throw SecureStoreError(.cantEncryptData)
             }

--- a/Sources/SecureStore/KeyManagerService.swift
+++ b/Sources/SecureStore/KeyManagerService.swift
@@ -53,7 +53,7 @@ extension KeyManagerService {
         ]
         
         var error: Unmanaged<CFError>?
-        guard let _ = SecKeyCreateRandomKey(attributes, &error) else {
+        guard SecKeyCreateRandomKey(attributes, &error) != nil else {
             guard let error = error?.takeRetainedValue() as? Error else {
                 throw SecureStoreError(.cantEncryptData)
             }


### PR DESCRIPTION
# DCMAW-21042 remove duplicate private key from being created

Added `serialised` on the KeyManagerServiceTests because I was getting issues with accessing keys from the keychain due to multiple tests accessing the keychain in parallel. 

# Checklist

## Before raising your pull request:
- [x] Commit messages that conform to conventional commit messages
- [x] Ran the app locally ensuring it builds 
- [x] Ran the tests locally ensuring they pass on Build
- [x] Pull request has a clear title with a short description about the feature or update
- [x] Created a `draft` pull request if it is not yet ready for review

## Before your pull request can be reviewed:
- [x] Met all of the acceptance criteria specified in the user story on Jira
- [x] Reviewed your own code to ensure you are following the style guidelines
- [x] Ran the app and tested the feature on a range of device sizes
      Please include iPod Touch, iPhone SE and iPhone 11 as a minimum.
- [x] Written Unit and Integration tests if needed

- [x] Met all accessibility requirements?
    - [x] Checked dynamic type sizes are applied
    - [x] Checked VoiceOver can navigate your new code
    - [x] Checked a user can navigate only using a keyboard around your new code 

## Before merging your pull request:
- [x] Ensure that the code coverage and SonarCloud checks have passed
- [x] Actioned and resolved all comments, reaching out to reviewers for clarifications if necessary.
- [x] Ran the app to ensure that no regressions have been caused by changes during code review.
